### PR TITLE
Make rpgp.pc relocatable

### DIFF
--- a/pgp-ffi/build.rs
+++ b/pgp-ffi/build.rs
@@ -28,7 +28,6 @@ fn main() {
         url = env::var("CARGO_PKG_HOMEPAGE").unwrap_or("".to_string()),
         version = env::var("CARGO_PKG_VERSION").unwrap(),
         libs_priv = libs_priv,
-        prefix = env::var("PREFIX").unwrap_or("/usr/local".to_string()),
     );
 
     fs::create_dir_all(target_path.join("pkgconfig")).unwrap();

--- a/pgp-ffi/rpgp.pc.in
+++ b/pgp-ffi/rpgp.pc.in
@@ -1,5 +1,6 @@
-prefix={prefix}
-libdir=${{prefix}}/lib
+prefix=${{pcfiledir}}/../..
+exec_prefix=${{prefix}}
+libdir=${{exec_prefix}}/lib
 includedir=${{prefix}}/include
 
 Name: {name}


### PR DESCRIPTION
This uses the built-in ${pcfiledir} variable to make the paths
relative to where the rpgp.pc file is.  It also uses the convention of
${exec_prefix} for libdir, which is perhaps a bit frivolous.

The motivation for this is that there are now binary packages
available for download which include rpgp.pc but do not have any
install step and thus do not modify the prefix.