### PR TITLE
Handle incomplete packet body properly

### DIFF
--- a/src/packet/many.rs
+++ b/src/packet/many.rs
@@ -109,6 +109,7 @@ impl<R: Read> Iterator for PacketParser<R> {
 
             if let Some((length, p)) = res_body {
                 info!("got packet: {:#?} {}", p, length);
+                assert!(length > 0);
                 b.consume(length);
                 return Some(p);
             }

--- a/src/packet/many.rs
+++ b/src/packet/many.rs
@@ -78,8 +78,10 @@ impl<R: Read> Iterator for PacketParser<R> {
                 ParseResult::Indeterminated => {
                     let mut body = rest.to_vec();
                     inner.read_to_end(&mut body)?;
-                    let p = single::body_parser(ver, tag, &body);
-                    Ok((rest.len() + body.len(), p))
+                    match single::body_parser(ver, tag, &body) {
+                        Err(Error::Incomplete(n)) => Err(Error::Incomplete(n)),
+                        p => Ok((rest.len() + body.len(), p)),
+                    }
                 }
                 ParseResult::Fixed(body) => {
                     let p = single::body_parser(ver, tag, body);

--- a/src/packet/many.rs
+++ b/src/packet/many.rs
@@ -278,4 +278,24 @@ mod tests {
             assert_eq!(tag, packet.tag(), "missmatch in packet {:?} ({})", p, e);
         }
     }
+
+    #[test]
+    fn incomplete_packet_parser() {
+        let _ = pretty_env_logger::try_init();
+        use std::io::Cursor;
+
+        let bytes: [u8; 1] = [0x97];
+        let parser = PacketParser::new(Cursor::new(bytes));
+        let mut packets = parser.filter_map(|p| {
+            // for now we are skipping any packets that we failed to parse
+            match p {
+                Ok(pp) => Some(pp),
+                Err(err) => {
+                    warn!("skipping packet: {:?}", err);
+                    None
+                }
+            }
+        });
+        assert!(packets.next().is_none());
+    }
 }

--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -170,6 +170,7 @@ pub fn body_parser(ver: Version, tag: Tag, body: &[u8]) -> Result<Packet> {
 
     match res {
         Ok(res) => Ok(res),
+        Err(Error::Incomplete(n)) => Err(Error::Incomplete(n)),
         Err(err) => {
             warn!("invalid packet: {:?} {:?}\n{}", err, tag, hex::encode(body));
             Err(Error::InvalidPacketContent(Box::new(err)))


### PR DESCRIPTION
Incomplete packet body should be handled the same as incomplete packet header.

If packet is incomplete and no more data is available, that is an error.