### PR TITLE
fix(line-reader): improve correctness of LineReader::seek

### DIFF
--- a/src/base64_reader.rs
+++ b/src/base64_reader.rs
@@ -35,7 +35,7 @@ impl<R: Read + Seek> Read for Base64Reader<R> {
         for i in 0..n {
             if !is_base64_token(into[i]) {
                 // the party is over
-                let back = (n as i64) - (i as i64);
+                let back = (i as i64) - (n as i64);
                 self.inner.seek(io::SeekFrom::Current(back))?;
 
                 // zero out the rest of what we read
@@ -133,6 +133,7 @@ mod tests {
             let mut buf = vec![0; 5];
             assert_eq!(r.read(&mut buf).unwrap(), 2);
             assert_eq!(buf, vec![b'K', b'w', 0, 0, 0]);
+            assert_eq!(r.into_inner().position(), 2);
         }
 
         {
@@ -142,6 +143,7 @@ mod tests {
             let mut buf = vec![0; 10];
             assert_eq!(r.read(&mut buf).unwrap(), 10);
             assert_eq!(&buf[..], b"Kwjk\n=Kwjk");
+            assert_eq!(r.into_inner().position(), 10);
         }
 
         {
@@ -150,6 +152,7 @@ mod tests {
             let mut r = Base64Reader::new(c);
             let mut buf = vec![0; 100];
             assert_eq!(r.read(&mut buf).unwrap(), 5);
+            assert_eq!(r.into_inner().position(), 5);
             assert_eq!(&buf[..5], b"Kwjk\n");
             assert_eq!(&buf[5..], &vec![0u8; 95][..]);
         }

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -317,4 +317,15 @@ mod tests {
         let read = r_inner.read(&mut buf).unwrap();
         assert_eq!(std::str::from_utf8(&buf[..read]).unwrap(), "ab\ncd\nef\ngh");
     }
+
+    #[test]
+    fn test_line_reader_starting_with_newline() {
+        let input = b"\n\nhelloworld";
+        let c = Cursor::new(&input[..]);
+        let mut r = LineReader::new(c);
+
+        let mut buf = vec![0; input.len() + 10];
+        assert_eq!(r.read(&mut buf).unwrap(), input.len() - 2);
+        assert_eq!(&buf[..input.len() - 2], &input[2..]);
+    }
 }

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -227,6 +227,26 @@ mod tests {
     }
 
     #[test]
+    fn test_line_reader_seek_forward() {
+        let input = b"hellonworld-";
+        let c = Cursor::new(&input[..]);
+        let mut r = LineReader::new(c);
+
+        let mut buf = vec![0; input.len() + 2];
+        assert_eq!(r.read(&mut buf).unwrap(), input.len());
+        assert_eq!(&buf[..input.len()], &input[..]);
+
+        // seek
+        assert_eq!(r.seek(io::SeekFrom::Current(-10)).unwrap(), 2);
+        assert_eq!(r.seek(io::SeekFrom::Current(4)).unwrap(), 6);
+        assert_eq!(r.seek(io::SeekFrom::Current(-2)).unwrap(), 4);
+
+        let mut buf = vec![0; input.len()];
+        assert_eq!(r.read(&mut buf).unwrap(), 8);
+        assert_eq!(&buf[..input.len() - 4], &input[4..]);
+    }
+
+    #[test]
     fn test_line_reader_seek_mix_1() {
         let input = b"ab\ncd\nef\ngh";
         //           "ab cd ef gh"

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -289,7 +289,7 @@ mod tests {
 
         // seek
         assert_eq!(
-            r.seek(io::SeekFrom::Current(input.len() as i64 - 3))
+            r.seek(io::SeekFrom::Current(-(input.len() as i64 - 3)))
                 .unwrap(),
             0
         );


### PR DESCRIPTION
Currently `LineBreak::seek` processes only `io::SeekFrom::Current(n)` and immediately converts `n` to its absolute value.

I test that forward and backward seek works as expected (currently it doesn't, hence draft PR).