### PR TITLE
feat: return the same error from decrypt_protected on invalid MDC

### DIFF
--- a/src/crypto/checksum.rs
+++ b/src/crypto/checksum.rs
@@ -23,14 +23,6 @@ pub fn simple(actual: &[u8], data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-/// SHA1 checksum, first 20 octets.
-#[inline]
-pub fn sha1(hash: &[u8], data: &[u8]) -> Result<()> {
-    ensure_eq!(hash, &calculate_sha1(data)[..], "invalid SHA1 checksum");
-
-    Ok(())
-}
-
 #[inline]
 pub fn simple_to_writer<W: io::Write>(data: &[u8], writer: &mut W) -> io::Result<()> {
     let mut hasher = SimpleChecksum::default();
@@ -88,6 +80,7 @@ impl Hasher for SimpleChecksum {
     }
 }
 
+/// SHA1 checksum, first 20 octets.
 #[inline]
 pub fn calculate_sha1(data: &[u8]) -> Vec<u8> {
     Sha1::digest(data)[..20].to_vec()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,6 +69,8 @@ pub enum Error {
     InvalidPacketContent(Box<Error>),
     #[fail(display = "Ed25519 {:?}", _0)]
     Ed25519SignatureError(SignatureError),
+    #[fail(display = "Modification Detection Code error")]
+    MdcError,
 }
 
 impl Error {
@@ -101,6 +103,7 @@ impl Error {
             Error::ParseIntError(_) => 24,
             Error::InvalidPacketContent(_) => 25,
             Error::Ed25519SignatureError(_) => 26,
+            Error::MdcError => 27,
         }
     }
 }


### PR DESCRIPTION
Previously `checksum::sha1()` called `ensure_eq!` and the resulting error
propagated upwards.  As it can end up in the logs or UI, it is better
to make it more generic to avoid accidental information leaks.

Additionally, compute SHA1 in advance, before performing the checks.
In the future, these checks can be made constant time, even though it
is out of scope of rPGP threat model for now.