### PR TITLE
fix: do not log sensitive information

### DIFF
--- a/src/composed/signed_key/key_parser_macros.rs
+++ b/src/composed/signed_key/key_parser_macros.rs
@@ -31,9 +31,8 @@ macro_rules! key_parser {
                     Some(n) => n,
                     None => return None
                 };
-                info!("  primary key: {:#?}", next);
                 let primary_key: $inner_key_type = err_opt!(next.try_into());
-                info!("  {:?}", primary_key.key_id());
+                info!("primary key: {:?}", primary_key.key_id());
 
                 // -- Zero or more revocation signatures
                 // -- followed by zero or more direct signatures in V4 keys

--- a/src/packet/secret_key_macro.rs
+++ b/src/packet/secret_key_macro.rs
@@ -178,8 +178,6 @@ macro_rules! impl_secret_key {
                 use $crate::crypto::ECCCurve;
                 use $crate::types::{PublicParams, SecretKeyRepr};
 
-                info!("signing data: {}", hex::encode(&data));
-
                 let mut signature: Option<Vec<$crate::types::Mpi>> = None;
                 self.unlock(key_pw, |priv_key| {
                     info!("unlocked key");

--- a/src/packet/signature/config.rs
+++ b/src/packet/signature/config.rs
@@ -94,9 +94,6 @@ impl SignatureConfig {
         let mut packet_buf = Vec::new();
         id.to_writer(&mut packet_buf)?;
 
-        info!("key:    ({:?}), {}", key.key_id(), hex::encode(&key_buf));
-        info!("packet: {}", hex::encode(&packet_buf));
-
         hasher.update(&key_buf);
 
         match self.version {
@@ -112,7 +109,6 @@ impl SignatureConfig {
 
                 let mut prefix_buf = [prefix, 0u8, 0u8, 0u8, 0u8];
                 BigEndian::write_u32(&mut prefix_buf[1..], packet_buf.len() as u32);
-                info!("prefix: {}", hex::encode(&prefix_buf));
 
                 // prefixes
                 hasher.update(&prefix_buf);

--- a/src/packet/signature/types.rs
+++ b/src/packet/signature/types.rs
@@ -131,7 +131,6 @@ impl Signature {
         let mut packet_buf = Vec::new();
         id.to_writer(&mut packet_buf)?;
 
-        info!("key:    ({:?}), {}", key.key_id(), hex::encode(&key_buf));
         info!("packet: {}", hex::encode(&packet_buf));
 
         hasher.update(&key_buf);


### PR DESCRIPTION
Logs may be leaked accidentally and additional processing increases the
chance that this information will remain in memory.

Logging can be added as needed if required for debugging.

Related to #43