### PR TITLE
Turn info!() that are used for debugging/tracing into debug!()

### DIFF
--- a/src/composed/message/decrypt.rs
+++ b/src/composed/message/decrypt.rs
@@ -18,7 +18,7 @@ pub fn decrypt_session_key<F>(
 where
     F: FnOnce() -> String,
 {
-    info!("decrypting session key");
+    debug!("decrypting session key");
 
     let mut key: Vec<u8> = Vec::new();
     let mut alg: Option<SymmetricKeyAlgorithm> = None;
@@ -37,7 +37,7 @@ where
         let algorithm = SymmetricKeyAlgorithm::from_u8(decrypted_key[0])
             .ok_or_else(|| format_err!("invalid symmetric key algorithm"))?;
         alg = Some(algorithm);
-        info!("alg: {:?}", alg);
+        debug!("alg: {:?}", alg);
 
         let (k, checksum) = match *priv_key {
             SecretKeyRepr::ECDH(_) => {
@@ -72,7 +72,7 @@ pub fn decrypt_session_key_with_password<F>(
 where
     F: FnOnce() -> String,
 {
-    info!("decrypting session key");
+    debug!("decrypting session key");
 
     let key = packet
         .s2k()
@@ -134,7 +134,7 @@ impl<'a> Iterator for MessageDecrypter<'a> {
             let mut res = packet.data()[..].to_vec();
             let protected = packet.tag() == Tag::SymEncryptedProtectedData;
 
-            info!("decrypting protected = {:?}", protected);
+            debug!("decrypting protected = {:?}", protected);
 
             let decrypted_packet: &[u8] = if protected {
                 err_opt!(self.alg.decrypt_protected(&self.key, &mut res))

--- a/src/composed/message/parser.rs
+++ b/src/composed/message/parser.rs
@@ -16,7 +16,7 @@ pub struct MessageParser<I: Sized + Iterator<Item = Packet>> {
 fn next<I: Iterator<Item = Packet>>(packets: &mut Peekable<I>) -> Option<Result<Message>> {
     while let Some(packet) = packets.by_ref().next() {
         // for packet in packets.by_ref() {
-        info!("{:?}: ", packet);
+        debug!("{:?}: ", packet);
         let tag = packet.tag();
         match tag {
             Tag::LiteralData => {

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -449,9 +449,9 @@ impl Message {
                             Esk::PublicKeyEncryptedSessionKey(k) => Some(k),
                             _ => None,
                         }) {
-                            info!("esk packet: {:?}", esk_packet);
-                            info!("{:?}", key.key_id());
-                            info!(
+                            debug!("esk packet: {:?}", esk_packet);
+                            debug!("{:?}", key.key_id());
+                            debug!(
                                 "{:?}",
                                 key.secret_subkeys
                                     .iter()

--- a/src/composed/signed_key/key_parser_macros.rs
+++ b/src/composed/signed_key/key_parser_macros.rs
@@ -32,17 +32,17 @@ macro_rules! key_parser {
                     None => return None
                 };
                 let primary_key: $inner_key_type = err_opt!(next.try_into());
-                info!("primary key: {:?}", primary_key.key_id());
+                debug!("primary key: {:?}", primary_key.key_id());
 
                 // -- Zero or more revocation signatures
                 // -- followed by zero or more direct signatures in V4 keys
-                info!("  signatures");
+                debug!("  signatures");
                 let mut revocation_signatures = Vec::new();
                 let mut direct_signatures = Vec::new();
 
                 while let Some(true) = packets.peek().map(|packet| packet.tag() == Tag::Signature) {
                     let packet = packets.next().expect("peeked");
-                    info!("parsing signature {:?}", packet.tag());
+                    debug!("parsing signature {:?}", packet.tag());
                     let sig: Signature = err_opt!(packet.try_into());
                     let typ = sig.typ();
 
@@ -59,20 +59,20 @@ macro_rules! key_parser {
 
                 // -- Zero or more User ID packets
                 // -- Zero or more User Attribute packets
-                info!("  user");
+                debug!("  user");
                 let mut users = Vec::new();
                 let mut user_attributes = Vec::new();
 
                 while let Some(true) = packets
                     .peek()
                     .map(|packet| {
-                        info!("peek {:?}", packet.tag());
+                        debug!("peek {:?}", packet.tag());
                         packet.tag() == Tag::UserId || packet.tag() == Tag::UserAttribute
                     })
                 {
                     let packet = packets.next().expect("peeked");
                     let tag = packet.tag();
-                    info!("  user data: {:?}", tag);
+                    debug!("  user data: {:?}", tag);
                     match tag {
                         Tag::UserId => {
                             let id: UserId = err_opt!(packet.try_into());
@@ -122,7 +122,7 @@ macro_rules! key_parser {
                     let mut $subkey_container = vec![];
                 )*
 
-                info!("  subkeys");
+                debug!("  subkeys");
 
                 while let Some(true) = packets.peek().map(|packet| {
                     $( packet.tag() == Tag::$subkey_tag || )* false

--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -72,7 +72,7 @@ pub fn build_ecdh_param(
 
 /// ECDH decryption.
 pub fn decrypt(priv_key: &ECDHSecretKey, mpis: &[Mpi], fingerprint: &[u8]) -> Result<Vec<u8>> {
-    info!("ECDH decrypt");
+    debug!("ECDH decrypt");
 
     let param = build_ecdh_param(&priv_key.oid, priv_key.alg_sym, priv_key.hash, fingerprint);
 
@@ -152,7 +152,7 @@ pub fn encrypt<R: CryptoRng + Rng>(
     q: &[u8],
     plain: &[u8],
 ) -> Result<Vec<Vec<u8>>> {
-    info!("ECDH encrypt");
+    debug!("ECDH encrypt");
 
     let param = build_ecdh_param(&curve.oid(), alg_sym, hash, fingerprint);
 

--- a/src/crypto/sym.rs
+++ b/src/crypto/sym.rs
@@ -30,7 +30,7 @@ macro_rules! decrypt {
 
         if $resync {
             unimplemented!("CFB resync is not here");
-        // info!("resync {}", hex::encode(&$prefix[2..$bs + 2]));
+        // debug!("resync {}", hex::encode(&$prefix[2..$bs + 2]));
         // let mut mode = Cfb::<$mode>::new_var($key, &$prefix[2..$bs + 2])?;
         // mode.decrypt($data);
         } else {
@@ -46,7 +46,7 @@ macro_rules! encrypt {
 
         if $resync {
             unimplemented!("CFB resync is not here");
-        // info!("resync {}", hex::encode(&$prefix[2..$bs + 2]));
+        // debug!("resync {}", hex::encode(&$prefix[2..$bs + 2]));
         // let mut mode = Cfb::<$mode>::new_var($key, &$prefix[2..$bs + 2])?;
         // mode.encrypt($data);
         } else {
@@ -154,7 +154,7 @@ impl SymmetricKeyAlgorithm {
     /// Uses an IV of all zeroes, as specified in the openpgp cfb mode. Does
     /// resynchronization.
     pub fn decrypt<'a>(self, key: &[u8], ciphertext: &'a mut [u8]) -> Result<&'a [u8]> {
-        info!("unprotected decrypt");
+        debug!("unprotected decrypt");
         let iv_vec = vec![0u8; self.block_size()];
         Ok(self.decrypt_with_iv(key, &iv_vec, ciphertext, true)?.1)
     }
@@ -163,7 +163,7 @@ impl SymmetricKeyAlgorithm {
     /// Uses an IV of all zeroes, as specified in the openpgp cfb mode.
     /// Does not do resynchronization.
     pub fn decrypt_protected<'a>(self, key: &[u8], ciphertext: &'a mut [u8]) -> Result<&'a [u8]> {
-        info!("protected decrypt");
+        debug!("protected decrypt");
         let iv_vec = vec![0u8; self.block_size()];
         let (prefix, res) = self.decrypt_with_iv(key, &iv_vec, ciphertext, false)?;
 
@@ -345,7 +345,7 @@ impl SymmetricKeyAlgorithm {
     /// Encrypt the data using CFB mode, without padding. Overwrites the input.
     /// Uses an IV of all zeroes, as specified in the openpgp cfb mode.
     pub fn encrypt(self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
-        info!("encrypt unprotected");
+        debug!("encrypt unprotected");
 
         let iv_vec = vec![0u8; self.block_size()];
 
@@ -372,7 +372,7 @@ impl SymmetricKeyAlgorithm {
     }
 
     pub fn encrypt_protected<'a>(self, key: &[u8], plaintext: &'a [u8]) -> Result<Vec<u8>> {
-        info!("protected encrypt");
+        debug!("protected encrypt");
 
         // MDC is 1 byte packet tag, 1 byte length prefix and 20 bytes SHA1 hash.
         let mdc_len = 22;

--- a/src/packet/many.rs
+++ b/src/packet/many.rs
@@ -97,7 +97,7 @@ impl<R: Read> Iterator for PacketParser<R> {
                 Ok(val) => Some(val),
                 Err(err) => match err {
                     Error::Incomplete(n) => {
-                        info!("incomplete {:?}", n);
+                        debug!("incomplete {:?}", n);
                         needed = Some(n);
                         None
                     }
@@ -110,7 +110,7 @@ impl<R: Read> Iterator for PacketParser<R> {
             };
 
             if let Some((length, p)) = res_body {
-                info!("got packet: {:#?} {}", p, length);
+                debug!("got packet: {:#?} {}", p, length);
                 assert!(length > 0);
                 b.consume(length);
                 return Some(p);

--- a/src/packet/packet_sum.rs
+++ b/src/packet/packet_sum.rs
@@ -144,7 +144,7 @@ pub fn write_packet(writer: &mut impl io::Write, packet: &impl PacketTrait) -> R
     let packet_version = packet.packet_version();
     let mut buf = Vec::new();
     packet.to_writer(&mut buf)?;
-    info!(
+    debug!(
         "write_packet {:?} {:?} (len: {})",
         &packet_version,
         packet.tag(),

--- a/src/packet/secret_key_macro.rs
+++ b/src/packet/secret_key_macro.rs
@@ -180,7 +180,7 @@ macro_rules! impl_secret_key {
 
                 let mut signature: Option<Vec<$crate::types::Mpi>> = None;
                 self.unlock(key_pw, |priv_key| {
-                    info!("unlocked key");
+                    debug!("unlocked key");
                     let sig = match *priv_key {
                         SecretKeyRepr::RSA(ref priv_key) => {
                             $crate::crypto::rsa::sign(priv_key, hash, data)

--- a/src/packet/signature/config.rs
+++ b/src/packet/signature/config.rs
@@ -85,7 +85,7 @@ impl SignatureConfig {
             self.is_certificate(),
             "can not sign non certificate as certificate"
         );
-        info!("signing certificate {:#?}", self.typ);
+        debug!("signing certificate {:#?}", self.typ);
 
         let mut hasher = self.hash_alg.new_hasher()?;
         let mut key_buf = Vec::new();
@@ -139,7 +139,7 @@ impl SignatureConfig {
     where
         F: FnOnce() -> String,
     {
-        info!(
+        debug!(
             "signing key binding: {:#?} - {:#?} - {:#?}",
             self, signing_key, key
         );
@@ -181,7 +181,7 @@ impl SignatureConfig {
     where
         F: FnOnce() -> String,
     {
-        info!("signing key (revocation): {:#?} - {:#?}", self, key);
+        debug!("signing key (revocation): {:#?} - {:#?}", self, key);
 
         let mut hasher = self.hash_alg.new_hasher()?;
 

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -265,7 +265,7 @@ fn pref_aead_alg(body: &[u8]) -> IResult<&[u8], Subpacket> {
 
 fn subpacket<'a>(typ: SubpacketType, body: &'a [u8]) -> IResult<&'a [u8], Subpacket> {
     use self::SubpacketType::*;
-    info!("parsing subpacket: {:?} {}", typ, hex::encode(body));
+    debug!("parsing subpacket: {:?} {}", typ, hex::encode(body));
 
     let res = match typ {
         SignatureCreationTime => signature_creation_time(body),

--- a/src/packet/signature/ser.rs
+++ b/src/packet/signature/ser.rs
@@ -289,7 +289,7 @@ impl Signature {
 
         // the actual signature
         for val in &self.signature {
-            info!("writing: {}", hex::encode(val));
+            debug!("writing: {}", hex::encode(val));
             val.to_writer(writer)?;
         }
 
@@ -305,7 +305,7 @@ impl Signature {
 
         // the actual signature
         for val in &self.signature {
-            info!("writing: {}", hex::encode(val));
+            debug!("writing: {}", hex::encode(val));
             val.to_writer(writer)?;
         }
 

--- a/src/packet/signature/types.rs
+++ b/src/packet/signature/types.rs
@@ -111,7 +111,7 @@ impl Signature {
         tag: Tag,
         id: &impl Serialize,
     ) -> Result<()> {
-        info!("verifying certificate {:#?}", self);
+        debug!("verifying certificate {:#?}", self);
 
         if let Some(issuer) = self.issuer() {
             if &key.key_id() != issuer {
@@ -131,7 +131,7 @@ impl Signature {
         let mut packet_buf = Vec::new();
         id.to_writer(&mut packet_buf)?;
 
-        info!("packet: {}", hex::encode(&packet_buf));
+        debug!("packet: {}", hex::encode(&packet_buf));
 
         hasher.update(&key_buf);
 
@@ -148,7 +148,7 @@ impl Signature {
 
                 let mut prefix_buf = [prefix, 0u8, 0u8, 0u8, 0u8];
                 BigEndian::write_u32(&mut prefix_buf[1..], packet_buf.len() as u32);
-                info!("prefix: {}", hex::encode(&prefix_buf));
+                debug!("prefix: {}", hex::encode(&prefix_buf));
 
                 // prefixes
                 hasher.update(&prefix_buf);
@@ -177,7 +177,7 @@ impl Signature {
         signing_key: &impl PublicKeyTrait,
         key: &impl PublicKeyTrait,
     ) -> Result<()> {
-        info!(
+        debug!(
             "verifying key binding: {:#?} - {:#?} - {:#?}",
             self, signing_key, key
         );
@@ -225,7 +225,7 @@ impl Signature {
 
     /// Verifies a direct key signature or a revocation.
     pub fn verify_key(&self, key: &impl PublicKeyTrait) -> Result<()> {
-        info!("verifying key (revocation): {:#?} - {:#?}", self, key);
+        debug!("verifying key (revocation): {:#?} - {:#?}", self, key);
 
         let key_id = key.key_id();
         if let Some(issuer) = self.issuer() {

--- a/src/packet/user_attribute.rs
+++ b/src/packet/user_attribute.rs
@@ -120,14 +120,14 @@ named_args!(parse(packet_version: Version) <UserAttribute>, do_parse!(
                 })
         ))
     >> ({
-        info!("attr with len {}", len);
+        debug!("attr with len {}", len);
         attr
     })
 ));
 
 impl Serialize for UserAttribute {
     fn to_writer<W: io::Write>(&self, writer: &mut W) -> Result<()> {
-        info!("write_packet_len {}", self.packet_len());
+        debug!("write_packet_len {}", self.packet_len());
         write_packet_length(self.packet_len(), writer)?;
 
         match self {

--- a/src/types/packet.rs
+++ b/src/types/packet.rs
@@ -87,7 +87,7 @@ impl Default for Version {
 
 impl Version {
     pub fn write_header(self, writer: &mut impl io::Write, tag: u8, len: usize) -> Result<()> {
-        info!("write_header {:?} {} {}", self, tag, len);
+        debug!("write_header {:?} {} {}", self, tag, len);
 
         match self {
             Version::Old => {

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -33,7 +33,7 @@ impl SignedUser {
 
     /// Verify all signatures. If signatures is empty, this fails.
     pub fn verify(&self, key: &impl PublicKeyTrait) -> Result<()> {
-        info!("verify signed user {:#?}", self);
+        debug!("verify signed user {:#?}", self);
         ensure!(!self.signatures.is_empty(), "no signatures found");
 
         for signature in &self.signatures {
@@ -87,7 +87,7 @@ impl SignedUserAttribute {
 
     /// Verify all signatures. If signatures is empty, this fails.
     pub fn verify(&self, key: &impl PublicKeyTrait) -> Result<()> {
-        info!("verify signed attribute {:?}", self);
+        debug!("verify signed attribute {:?}", self);
         ensure!(!self.signatures.is_empty(), "no signatures found");
 
         for signature in &self.signatures {


### PR DESCRIPTION
This would greatly improve the logging in applications that are using rpgp.
Note that some of those message could even become trace!().

See issue #75.
