### PR TITLE
nom 5 with custom errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.6"
 smallvec = "0.6.9"
 cast5 = "0.6.0"
 rsa = "^0.1.4"
-nom = "^4.2"
+nom = "5"
 zeroize = { version = "0.10.1", features = ["zeroize_derive"] }
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 

--- a/src/armor/reader.rs
+++ b/src/armor/reader.rs
@@ -11,6 +11,7 @@ use nom::{
     self,
     character::streaming::{digit1, line_ending, not_line_ending},
     InputIter, InputLength, Slice,
+    IResult
 };
 
 use crate::base64_decoder::Base64Decoder;
@@ -99,7 +100,9 @@ impl fmt::Display for PKCS1Type {
 }
 
 // Parses a single ascii armor header separator.
-named!(armor_header_sep, tag!("-----"));
+fn armor_header_sep(input: &[u8]) -> IResult<&[u8], &[u8], crate::errors::Error> {
+    tag!(input, "-----")
+}
 
 #[inline]
 fn parse_digit(x: &[u8]) -> Result<usize> {

--- a/src/armor/reader.rs
+++ b/src/armor/reader.rs
@@ -7,7 +7,11 @@ use base64;
 use buf_redux::BufReader;
 use byteorder::{BigEndian, ByteOrder};
 use crc24;
-use nom::{self, digit, line_ending, not_line_ending, InputIter, InputLength, Slice};
+use nom::{
+    self,
+    character::streaming::{digit1, line_ending, not_line_ending},
+    InputIter, InputLength, Slice,
+};
 
 use crate::base64_decoder::Base64Decoder;
 use crate::base64_reader::Base64Reader;
@@ -108,13 +112,13 @@ fn parse_digit(x: &[u8]) -> Result<usize> {
 #[rustfmt::skip]
 named!(
     armor_header_type<BlockType>,
-    alt_complete!(
+    alt!(
         map!(tag!("PGP PUBLIC KEY BLOCK"), |_| BlockType::PublicKey)
       | map!(tag!("PGP PRIVATE KEY BLOCK"), |_| BlockType::PrivateKey)
       | do_parse!(
           tag!("PGP MESSAGE, PART ")
-        >> x: map_res!(digit, parse_digit)
-        >> y: opt!(preceded!(tag!("/"), map_res!(digit, parse_digit)))
+        >> x: map_res!(digit1, parse_digit)
+        >> y: opt!(preceded!(tag!("/"), map_res!(digit1, parse_digit)))
         >> ({
             BlockType::MultiPartMessage(x, y.unwrap_or(0))
         })

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub const MPI_TOO_LONG: u32 = 1000;
 pub enum Error {
     #[fail(display = "failed to parse")]
     ParsingError(nom::error::ErrorKind),
+    #[fail(display = "MPI is too long")]
+    MpiTooLong,
     #[fail(display = "invalid input")]
     InvalidInput,
     #[fail(display = "incomplete input: {:?}", _0)]
@@ -80,6 +82,12 @@ impl<I> nom::error::ParseError<I> for Error {
 
     fn append(input: I, kind: nom::error::ErrorKind, _other: Self) -> Self {
         Self::from_error_kind(input, kind)
+    }
+}
+
+impl nom::ErrorConvert<Error> for (((&[u8], usize), nom::error::ErrorKind)) {
+    fn convert(self) -> Error {
+        Error::ParsingError(self.1)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,6 +93,12 @@ impl<'a> From<nom::Err<(&'a [u8], nom::error::ErrorKind)>> for Error {
     }
 }
 
+impl<'a> From<Error> for nom::Err<Error> {
+    fn from(err: Error) -> nom::Err<Error> {
+        nom::Err::Error(err)
+    }
+}
+
 impl<'a> From<Error> for nom::Err<(&'a [u8], nom::error::ErrorKind)> {
     fn from(err: Error) -> nom::Err<(&'a [u8], nom::error::ErrorKind)> {
         //FIXME was: nom::Err::Error((&b""[..], nom::error::ErrorKind::Custom(err.as_code())))

--- a/src/packet/literal_data.rs
+++ b/src/packet/literal_data.rs
@@ -5,10 +5,11 @@ use chrono::{DateTime, SubsecRound, TimeZone, Utc};
 use nom::{
     combinator::rest,
     number::streaming::{be_u32, be_u8},
+    IResult,
 };
 use num_traits::FromPrimitive;
 
-use crate::errors::Result;
+use crate::errors::*;
 use crate::line_writer::LineBreak;
 use crate::normalize_lines::Normalized;
 use crate::packet::PacketTrait;
@@ -109,7 +110,8 @@ impl Serialize for LiteralData {
 }
 
 #[rustfmt::skip]
-named_args!(parse(packet_version: Version)<LiteralData>, do_parse!(
+fn parse(input: &[u8], packet_version: Version) -> IResult<&[u8], LiteralData, Error> {
+    do_parse!(input,
            mode: map_opt!(be_u8, DataMode::from_u8)
     >> name_len: be_u8
     >>     name: map!(take!(name_len), read_string)
@@ -121,8 +123,8 @@ named_args!(parse(packet_version: Version)<LiteralData>, do_parse!(
             created,
             file_name: name,
             data: data.to_vec(),
-    })
-));
+    }))
+}
 
 impl PacketTrait for LiteralData {
     fn packet_version(&self) -> Version {

--- a/src/packet/literal_data.rs
+++ b/src/packet/literal_data.rs
@@ -2,7 +2,10 @@ use std::{fmt, io};
 
 use byteorder::{BigEndian, WriteBytesExt};
 use chrono::{DateTime, SubsecRound, TimeZone, Utc};
-use nom::{be_u32, be_u8, rest};
+use nom::{
+    combinator::rest,
+    number::streaming::{be_u32, be_u8},
+};
 use num_traits::FromPrimitive;
 
 use crate::errors::Result;

--- a/src/packet/one_pass_signature.rs
+++ b/src/packet/one_pass_signature.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::be_u8;
+use nom::number::streaming::be_u8;
 use num_traits::FromPrimitive;
 
 use crate::crypto::hash::HashAlgorithm;

--- a/src/packet/one_pass_signature.rs
+++ b/src/packet/one_pass_signature.rs
@@ -1,11 +1,11 @@
 use std::io;
 
-use nom::number::streaming::be_u8;
+use nom::{number::streaming::be_u8, IResult};
 use num_traits::FromPrimitive;
 
 use crate::crypto::hash::HashAlgorithm;
 use crate::crypto::public_key::PublicKeyAlgorithm;
-use crate::errors::Result;
+use crate::errors::*;
 use crate::packet::signature::SignatureType;
 use crate::packet::PacketTrait;
 use crate::ser::Serialize;
@@ -55,7 +55,8 @@ impl OnePassSignature {
 }
 
 #[rustfmt::skip]
-named_args!(parse(packet_version: Version) <OnePassSignature>, do_parse!(
+fn parse(input: &[u8], packet_version: Version) -> IResult<&[u8], OnePassSignature, Error> {
+    do_parse!(input,
          version: be_u8
     >>       typ: map_opt!(be_u8, SignatureType::from_u8)
     >>      hash: map_opt!(be_u8, HashAlgorithm::from_u8)
@@ -70,8 +71,8 @@ named_args!(parse(packet_version: Version) <OnePassSignature>, do_parse!(
         pub_algorithm: pub_alg,
         key_id,
         last,
-    })
-));
+    }))
+}
 
 impl Serialize for OnePassSignature {
     fn to_writer<W: io::Write>(&self, writer: &mut W) -> Result<()> {

--- a/src/packet/public_key_encrypted_session_key.rs
+++ b/src/packet/public_key_encrypted_session_key.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use byteorder::{BigEndian, ByteOrder};
-use nom::be_u8;
+use nom::number::streaming::be_u8;
 use num_traits::FromPrimitive;
 use rand::{CryptoRng, Rng};
 

--- a/src/packet/public_key_encrypted_session_key.rs
+++ b/src/packet/public_key_encrypted_session_key.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use byteorder::{BigEndian, ByteOrder};
-use nom::{IResult, number::streaming::be_u8};
+use nom::{number::streaming::be_u8, IResult};
 use num_traits::FromPrimitive;
 use rand::{CryptoRng, Rng};
 

--- a/src/packet/public_key_parser.rs
+++ b/src/packet/public_key_parser.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, TimeZone, Utc};
-use nom::{be_u16, be_u32, be_u8};
+use nom::number::streaming::{be_u16, be_u32, be_u8};
 use num_traits::FromPrimitive;
 
 use crate::crypto::ecc_curve::ecc_curve_from_oid;
@@ -129,14 +129,14 @@ named_args!(old_public_key_parser<'a>(key_ver: &'a KeyVersion) <(KeyVersion, Pub
 #[rustfmt::skip]
 named!(pub(crate) parse<(KeyVersion, PublicKeyAlgorithm, DateTime<Utc>, Option<u16>, PublicParams)>, do_parse!(
        key_ver: map_opt!(be_u8, KeyVersion::from_u8)
-    >>     key: switch!(value!(&key_ver),
-                        &KeyVersion::V2 => call!(
+    >>     key: switch!(value!(key_ver),
+                        KeyVersion::V2 => call!(
                             old_public_key_parser, &key_ver
                         ) |
-                        &KeyVersion::V3 => call!(
+                        KeyVersion::V3 => call!(
                             old_public_key_parser, &key_ver
                         ) |
-                        &KeyVersion::V4 => call!(
+                        KeyVersion::V4 => call!(
                             new_public_key_parser, &key_ver
                         )
         )

--- a/src/packet/secret_key_parser.rs
+++ b/src/packet/secret_key_parser.rs
@@ -1,5 +1,8 @@
 use chrono::{DateTime, TimeZone, Utc};
-use nom::{be_u16, be_u32, be_u8, rest};
+use nom::{
+    combinator::rest,
+    number::streaming::{be_u16, be_u32, be_u8},
+};
 use num_traits::FromPrimitive;
 
 use crate::crypto::PublicKeyAlgorithm;
@@ -36,14 +39,14 @@ named_args!(old_private_key_parser<'a>(key_ver: &'a KeyVersion) <(KeyVersion, Pu
 #[rustfmt::skip]
 named!(pub(crate) parse<(KeyVersion, PublicKeyAlgorithm, DateTime<Utc>, Option<u16>, PublicParams, SecretParams)>, do_parse!(
        key_ver: map_opt!(be_u8, KeyVersion::from_u8)
-    >>     key: switch!(value!(&key_ver),
-                       &KeyVersion::V2 => call!(
+    >>     key: switch!(value!(key_ver),
+                       KeyVersion::V2 => call!(
                            old_private_key_parser, &key_ver
                        ) |
-                       &KeyVersion::V3 => call!(
+                       KeyVersion::V3 => call!(
                            old_private_key_parser, &key_ver
                        ) |
-                       &KeyVersion::V4 => call!(
+                       KeyVersion::V4 => call!(
                            new_private_key_parser, &key_ver
                        )
                 )

--- a/src/packet/secret_key_parser.rs
+++ b/src/packet/secret_key_parser.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use nom::{
     combinator::rest,
     number::streaming::{be_u16, be_u32, be_u8},
-    IResult
+    IResult,
 };
 use num_traits::FromPrimitive;
 
@@ -37,7 +37,6 @@ fn old_private_key_parser<'a>(input: &'a [u8], key_ver: &'a KeyVersion) -> IResu
     >>     params: call!(parse_pub_priv_fields, alg)
     >> (*key_ver, alg, created_at, Some(exp), params.0, params.1))
 }
-
 
 // Parse a private key packet (Tag 5)
 // Ref: https://tpools.ietf.org/html/rfc4880.html#section-5.5.1.3

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -2,7 +2,11 @@ use std::boxed::Box;
 use std::str;
 
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
-use nom::{be_u16, be_u32, be_u8, rest, IResult};
+use nom::{
+    combinator::rest,
+    number::streaming::{be_u16, be_u32, be_u8},
+    IResult,
+};
 use num_traits::FromPrimitive;
 use smallvec::SmallVec;
 
@@ -425,11 +429,11 @@ fn invalid_version<'a>(_body: &'a [u8], version: SignatureVersion) -> IResult<&'
 #[rustfmt::skip]
 named_args!(parse(packet_version: Version) <Signature>, do_parse!(
          version: map_opt!(be_u8, SignatureVersion::from_u8)
-    >> signature: switch!(value!(&version),
-                      &SignatureVersion::V2 => call!(v3_parser, packet_version, version) |
-                      &SignatureVersion::V3 => call!(v3_parser, packet_version, version) |
-                      &SignatureVersion::V4 => call!(v4_parser, packet_version, version) |
-                      &SignatureVersion::V5 => call!(v4_parser, packet_version, version) |
+    >> signature: switch!(value!(version),
+                      SignatureVersion::V2 => call!(v3_parser, packet_version, version) |
+                      SignatureVersion::V3 => call!(v3_parser, packet_version, version) |
+                      SignatureVersion::V4 => call!(v4_parser, packet_version, version) |
+                      SignatureVersion::V5 => call!(v4_parser, packet_version, version) |
                       _ => call!(invalid_version, version)
     )
     >> (signature)

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -42,7 +42,10 @@ fn dt_from_timestamp(ts: u32) -> DateTime<Utc> {
 fn signature_creation_time(i: &[u8]) -> IResult<&[u8], Subpacket, Error> {
     // 4-octet time field
     let (rest, date) = be_u32(i)?;
-    Ok((rest, Subpacket::SignatureCreationTime(dt_from_timestamp(date))))
+    Ok((
+        rest,
+        Subpacket::SignatureCreationTime(dt_from_timestamp(date)),
+    ))
 }
 
 // Parse an issuer subpacket
@@ -116,9 +119,9 @@ fn signature_expiration_time(input: &[u8]) -> IResult<&[u8], Subpacket, Error> {
 // Parse a exportable certification subpacket.
 // Ref: https://tools.ietf.org/html/rfc4880.html#section-5.2.3.11
 fn exportable_certification(input: &[u8]) -> IResult<&[u8], Subpacket, Error> {
-    map!(input, complete!(be_u8), |v| Subpacket::ExportableCertification(
-        v == 1
-    ))
+    map!(input, complete!(be_u8), |v| {
+        Subpacket::ExportableCertification(v == 1)
+    })
 }
 
 // Parse a revocable subpacket
@@ -329,7 +332,10 @@ fn subpackets(input: &[u8]) -> IResult<&[u8], Vec<Subpacket>, crate::errors::Err
     >> (p))))
 }
 
-fn actual_signature<'a>(input: &'a [u8], typ: &PublicKeyAlgorithm) -> IResult<&'a [u8], Vec<Mpi>, crate::errors::Error> {
+fn actual_signature<'a>(
+    input: &'a [u8],
+    typ: &PublicKeyAlgorithm,
+) -> IResult<&'a [u8], Vec<Mpi>, crate::errors::Error> {
     switch!(input,
     value!(typ),
     &PublicKeyAlgorithm::RSA |
@@ -431,7 +437,10 @@ fn v4_parser(input: &[u8], packet_version: Version, version: SignatureVersion) -
     )))
 }
 
-fn invalid_version<'a>(_body: &'a [u8], version: SignatureVersion) -> IResult<&'a [u8], Signature, Error> {
+fn invalid_version<'a>(
+    _body: &'a [u8],
+    version: SignatureVersion,
+) -> IResult<&'a [u8], Signature, Error> {
     unimplemented!("unknown signature version {:?}", version);
 }
 

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -39,14 +39,11 @@ fn dt_from_timestamp(ts: u32) -> DateTime<Utc> {
 
 // Parse a signature creation time subpacket
 // Ref: https://tools.ietf.org/html/rfc4880.html#section-5.2.3.4
-named!(
-    signature_creation_time<Subpacket>,
-    map!(
-        // 4-octet time field
-        be_u32,
-        |date| Subpacket::SignatureCreationTime(dt_from_timestamp(date))
-    )
-);
+fn signature_creation_time(i: &[u8]) -> IResult<&[u8], Subpacket> {
+    // 4-octet time field
+    let (rest, date) = be_u32(i)?;
+    Ok((rest, Subpacket::SignatureCreationTime(dt_from_timestamp(date))))
+}
 
 // Parse an issuer subpacket
 // Ref: https://tools.ietf.org/html/rfc4880.html#section-5.2.3.5

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -15,7 +15,7 @@ use crate::crypto::hash::HashAlgorithm;
 use crate::crypto::public_key::PublicKeyAlgorithm;
 use crate::crypto::sym::SymmetricKeyAlgorithm;
 use crate::de::Deserialize;
-use crate::errors::Result;
+use crate::errors::{Error, Result};
 use crate::packet::signature::types::*;
 use crate::types::{
     mpi, CompressionAlgorithm, KeyId, KeyVersion, Mpi, MpiRef, RevocationKey, RevocationKeyClass,

--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -23,7 +23,8 @@ use crate::util::{u16_as_usize, u32_as_usize, u8_as_usize};
 // Parses an old format packet header
 // Ref: https://tools.ietf.org/html/rfc4880.html#section-4.2.1
 #[rustfmt::skip]
-named!(old_packet_header(&[u8]) -> (Version, Tag, PacketLength), bits!(do_parse!(
+fn old_packet_header(input: &[u8]) -> IResult<&[u8], (Version, Tag, PacketLength)> {
+    bits!(input, do_parse!(
     // First bit is always 1
             tag_bits!(1u8, 1)
     // Version: 0
@@ -41,8 +42,8 @@ named!(old_packet_header(&[u8]) -> (Version, Tag, PacketLength), bits!(do_parse!
         2 => map!(take_bits!(32u8), |val| u32_as_usize(val).into()) |
         3 => value!(PacketLength::Indeterminated)
     )
-    >> ((ver, tag, len))
-)));
+    >> ((ver, tag, len))))
+}
 
 #[rustfmt::skip]
 fn read_packet_len(input: &[u8]) -> IResult<&[u8], PacketLength> {

--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -1,7 +1,11 @@
 // comes from inside somewhere of nom
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::useless_let_if_seq))]
 
-use nom::{self, be_u32, be_u8, Err, IResult};
+use nom::{
+    self,
+    number::streaming::{be_u32, be_u8},
+    Err, IResult,
+};
 use num_traits::FromPrimitive;
 
 use crate::de::Deserialize;
@@ -21,20 +25,20 @@ use crate::util::{u16_as_usize, u32_as_usize, u8_as_usize};
 #[rustfmt::skip]
 named!(old_packet_header(&[u8]) -> (Version, Tag, PacketLength), bits!(do_parse!(
     // First bit is always 1
-            tag_bits!(u8, 1, 1)
+            tag_bits!(1u8, 1)
     // Version: 0
-    >> ver: map_opt!(tag_bits!(u8, 1, 0), Version::from_u8)
+    >> ver: map_opt!(tag_bits!(1u8, 0), Version::from_u8)
     // Packet Tag
-    >> tag: map_opt!(take_bits!(u8, 4), Tag::from_u8)
+    >> tag: map_opt!(take_bits!(4u8), Tag::from_u8)
     // Packet Length Type
-    >> len_type: take_bits!(u8, 2)
+    >> len_type: take_bits!(2u8)
     >> len: switch!(value!(len_type),
         // One-Octet Lengths
-        0 => map!(take_bits!(u8, 8), |val| u8_as_usize(val).into())    |
+        0 => map!(take_bits!(8u8), |val| u8_as_usize(val).into())    |
         // Two-Octet Lengths
-        1 => map!(take_bits!(u16, 16), |val| u16_as_usize(val).into()) |
+        1 => map!(take_bits!(16u8), |val| u16_as_usize(val).into()) |
         // Four-Octet Lengths
-        2 => map!(take_bits!(u32, 32), |val| u32_as_usize(val).into()) |
+        2 => map!(take_bits!(32u8), |val| u32_as_usize(val).into()) |
         3 => value!(PacketLength::Indeterminated)
     )
     >> ((ver, tag, len))
@@ -108,11 +112,11 @@ fn read_partial_bodies<'a>(input: &'a [u8], len: usize) -> IResult<&'a [u8], Par
 #[rustfmt::skip]
 named!(new_packet_header(&[u8]) -> (Version, Tag, PacketLength), bits!(do_parse!(
     // First bit is always 1
-             tag_bits!(u8, 1, 1)
+             tag_bits!(1u8, 1)
     // Version: 1
-    >>  ver: map_opt!(tag_bits!(u8, 1, 1), Version::from_u8)
+    >>  ver: map_opt!(tag_bits!(1u8, 1), Version::from_u8)
     // Packet Tag
-    >>  tag: map_opt!(take_bits!(u8, 6), Tag::from_u8)
+    >>  tag: map_opt!(take_bits!(6u8), Tag::from_u8)
     >> len: bytes!(read_packet_len)
     >> ((ver, tag, len))
 )));
@@ -129,10 +133,10 @@ pub enum ParseResult<'a> {
 #[rustfmt::skip]
 named!(pub parser<(Version, Tag, PacketLength, ParseResult<'_>)>, do_parse!(
        head: alt!(new_packet_header | old_packet_header)
-    >> body: switch!(value!(&head.2),
-        PacketLength::Fixed(length)   => map!(take!(*length), |v| ParseResult::Fixed(v)) |
+    >> body: switch!(value!(head.2),
+        PacketLength::Fixed(length)   => map!(take!(length), |v| ParseResult::Fixed(v)) |
         PacketLength::Indeterminated  => value!(ParseResult::Indeterminated) |
-        PacketLength::Partial(length) => call!(read_partial_bodies, *length)
+        PacketLength::Partial(length) => call!(read_partial_bodies, length)
     )
     >> (head.0, head.1, head.2, body)
 ));

--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -63,7 +63,10 @@ fn read_packet_len(input: &[u8]) -> IResult<&[u8], PacketLength, crate::errors::
     >> (len))
 }
 
-fn read_partial_bodies<'a>(input: &'a [u8], len: usize) -> IResult<&'a [u8], ParseResult<'a>, crate::errors::Error> {
+fn read_partial_bodies<'a>(
+    input: &'a [u8],
+    len: usize,
+) -> IResult<&'a [u8], ParseResult<'a>, crate::errors::Error> {
     if input.len() < len {
         return Err(nom::Err::Incomplete(nom::Needed::Size(len - input.len())));
     }

--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -45,7 +45,8 @@ named!(old_packet_header(&[u8]) -> (Version, Tag, PacketLength), bits!(do_parse!
 )));
 
 #[rustfmt::skip]
-named!(read_packet_len(&[u8]) -> PacketLength, do_parse!(
+fn read_packet_len(input: &[u8]) -> IResult<&[u8], PacketLength> {
+    do_parse!(input,
        olen: be_u8
     >>  len: switch!(value!(olen),
                // One-Octet Lengths
@@ -59,8 +60,8 @@ named!(read_packet_len(&[u8]) -> PacketLength, do_parse!(
                // Five-Octet Lengths
                255       => map!(be_u32, |v| u32_as_usize(v).into())
     )
-    >> (len)
-));
+    >> (len))
+}
 
 fn read_partial_bodies<'a>(input: &'a [u8], len: usize) -> IResult<&'a [u8], ParseResult<'a>> {
     if input.len() < len {

--- a/src/packet/sym_key_encrypted_session_key.rs
+++ b/src/packet/sym_key_encrypted_session_key.rs
@@ -1,6 +1,9 @@
 use std::io;
 
-use nom::{IResult, {combinator::rest, number::streaming::be_u8}};
+use nom::{
+    IResult,
+    {combinator::rest, number::streaming::be_u8},
+};
 use num_traits::FromPrimitive;
 
 use crate::crypto::sym::SymmetricKeyAlgorithm;

--- a/src/packet/sym_key_encrypted_session_key.rs
+++ b/src/packet/sym_key_encrypted_session_key.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::{combinator::rest, number::streaming::be_u8};
+use nom::{IResult, {combinator::rest, number::streaming::be_u8}};
 use num_traits::FromPrimitive;
 
 use crate::crypto::sym::SymmetricKeyAlgorithm;
@@ -80,7 +80,8 @@ impl SymKeyEncryptedSessionKey {
 }
 
 #[rustfmt::skip]
-named_args!(parse(packet_version: Version) <SymKeyEncryptedSessionKey>, do_parse!(
+fn parse<'a>(input: &[u8], packet_version: Version) -> IResult<&[u8], SymKeyEncryptedSessionKey, crate::errors::Error> {
+    do_parse!(input,
               version: be_u8
     >>        sym_alg: map_opt!(be_u8, SymmetricKeyAlgorithm::from_u8)
     >>            s2k: s2k_parser
@@ -99,8 +100,8 @@ named_args!(parse(packet_version: Version) <SymKeyEncryptedSessionKey>, do_parse
             s2k,
             encrypted_key,
         }
-    })
-));
+    }))
+}
 
 impl Serialize for SymKeyEncryptedSessionKey {
     fn to_writer<W: io::Write>(&self, writer: &mut W) -> Result<()> {

--- a/src/packet/sym_key_encrypted_session_key.rs
+++ b/src/packet/sym_key_encrypted_session_key.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::{be_u8, rest};
+use nom::{combinator::rest, number::streaming::be_u8};
 use num_traits::FromPrimitive;
 
 use crate::crypto::sym::SymmetricKeyAlgorithm;

--- a/src/packet/user_attribute.rs
+++ b/src/packet/user_attribute.rs
@@ -3,7 +3,10 @@ use std::{fmt, io};
 use chrono::{SubsecRound, Utc};
 
 use byteorder::{LittleEndian, WriteBytesExt};
-use nom::{be_u8, le_u16, rest};
+use nom::{
+    combinator::rest,
+    number::streaming::{be_u8, le_u16},
+};
 
 use crate::errors::Result;
 use crate::packet::{PacketTrait, Signature, SignatureConfigBuilder, SignatureType, Subpacket};

--- a/src/packet/user_attribute.rs
+++ b/src/packet/user_attribute.rs
@@ -6,7 +6,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use nom::{
     combinator::rest,
     number::streaming::{be_u8, le_u16},
-    IResult
+    IResult,
 };
 
 use crate::errors::Result;

--- a/src/types/packet.rs
+++ b/src/types/packet.rs
@@ -17,7 +17,7 @@ pub struct Packet {
 }
 
 /// Represents the packet length.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum PacketLength {
     Fixed(usize),
     Indeterminated,

--- a/src/types/params/secret.rs
+++ b/src/types/params/secret.rs
@@ -1,12 +1,15 @@
 use std::io;
 
-use nom::{combinator::rest_len, number::streaming::be_u8};
+use nom::{
+    IResult,
+    {combinator::rest_len, number::streaming::be_u8},
+};
 use num_traits::FromPrimitive;
 use zeroize::Zeroize;
 
 use crate::crypto::public_key::PublicKeyAlgorithm;
 use crate::crypto::sym::SymmetricKeyAlgorithm;
-use crate::errors::Result;
+use crate::errors::*;
 use crate::ser::Serialize;
 use crate::types::*;
 
@@ -76,7 +79,8 @@ impl Serialize for SecretParams {
 
 // Parse possibly encrypted private fields of a key.
 #[rustfmt::skip]
-named_args!(parse_secret_fields(alg: PublicKeyAlgorithm) <(SecretParams, Option<&[u8]>)>, do_parse!(
+fn parse_secret_fields(input: &[u8], alg: PublicKeyAlgorithm) -> IResult<&[u8], (SecretParams, Option<&[u8]>), Error> {
+    do_parse!(input,
           s2k_typ: be_u8
     >> enc_params: switch!(value!(s2k_typ),
                    // 0 is no encryption
@@ -131,5 +135,5 @@ named_args!(parse_secret_fields(alg: PublicKeyAlgorithm) <(SecretParams, Option<
             }
         };
         (res, checksum)
-    })
-));
+               }))
+}

--- a/src/types/params/secret.rs
+++ b/src/types/params/secret.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::{be_u8, rest_len};
+use nom::{combinator::rest_len, number::streaming::be_u8};
 use num_traits::FromPrimitive;
 use zeroize::Zeroize;
 

--- a/src/types/s2k.rs
+++ b/src/types/s2k.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::be_u8;
+use nom::number::streaming::be_u8;
 use num_traits::FromPrimitive;
 use rand::{CryptoRng, Rng};
 

--- a/src/types/s2k.rs
+++ b/src/types/s2k.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::{IResult, number::streaming::be_u8};
+use nom::{number::streaming::be_u8, IResult};
 use num_traits::FromPrimitive;
 use rand::{CryptoRng, Rng};
 
@@ -184,7 +184,7 @@ fn has_count(typ: StringToKeyType) -> bool {
 }
 
 #[rustfmt::skip]
-pub fn s2k_parser(input: &[u8], typ: StringToKey) -> IResult<&[u8], StringToKey, crate::errors::Error> {
+pub fn s2k_parser(input: &[u8]) -> IResult<&[u8], StringToKey, crate::errors::Error> {
     do_parse!(input,
          typ: map_opt!(be_u8, StringToKeyType::from_u8)
     >>  hash: map_opt!(be_u8, HashAlgorithm::from_u8)

--- a/src/types/s2k.rs
+++ b/src/types/s2k.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use nom::number::streaming::be_u8;
+use nom::{IResult, number::streaming::be_u8};
 use num_traits::FromPrimitive;
 use rand::{CryptoRng, Rng};
 
@@ -184,7 +184,8 @@ fn has_count(typ: StringToKeyType) -> bool {
 }
 
 #[rustfmt::skip]
-named!(pub s2k_parser<StringToKey>, do_parse!(
+pub fn s2k_parser(input: &[u8], typ: StringToKey) -> IResult<&[u8], StringToKey, crate::errors::Error> {
+    do_parse!(input,
          typ: map_opt!(be_u8, StringToKeyType::from_u8)
     >>  hash: map_opt!(be_u8, HashAlgorithm::from_u8)
     >>  salt: cond!(has_salt(typ), map!(take!(8), |v| v.to_vec()))
@@ -194,8 +195,8 @@ named!(pub s2k_parser<StringToKey>, do_parse!(
         hash,
         salt,
         count,
-    })
-));
+    }))
+}
 
 impl Serialize for StringToKey {
     fn to_writer<W: io::Write>(&self, writer: &mut W) -> Result<()> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -45,7 +45,9 @@ pub fn base64_token(input: &[u8]) -> nom::IResult<&[u8], &[u8], errors::Error> {
     for (idx, item) in input.iter_indices() {
         if !is_base64_token(item) {
             if idx == 0 {
-                return Err(Err::Failure(errors::Error::ParsingError(nom::error::ErrorKind::AlphaNumeric)));
+                return Err(Err::Failure(errors::Error::ParsingError(
+                    nom::error::ErrorKind::AlphaNumeric,
+                )));
             } else {
                 return Ok((input.slice(idx..), input.slice(0..idx)));
             }


### PR DESCRIPTION
This PR is built on top of #78, which already kinda works.

nom 5 removed `ErrorKind::Custom` and requires that user of the library implements their own error type instead. Since `named_args!` macro [does not support custom errors yet](https://github.com/Geal/nom/issues/455) and `named!` macro does not offer much, I am replacing calls to both with ordinary functions, so I can specify error type explicitly.