### PR TITLE
feat(key): add Signed(Public|Secret)Key::expires_at() method

### DIFF
--- a/src/composed/signed_key/public.rs
+++ b/src/composed/signed_key/public.rs
@@ -57,8 +57,10 @@ impl SignedPublicKey {
         }
     }
 
+    /// Get the public key expiration as a date.
     pub fn expires_at(&self) -> Option<DateTime<Utc>> {
-        self.details.expires_at(self.primary_key.created_at())
+        let expiration = self.details.key_expiration_time()?;
+        Some(*self.primary_key.created_at() + expiration)
     }
 
     fn verify_public_subkeys(&self) -> Result<()> {

--- a/src/composed/signed_key/public.rs
+++ b/src/composed/signed_key/public.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io;
 
+use chrono::{DateTime, Utc};
 use rand::{CryptoRng, Rng};
 
 use crate::armor;
@@ -54,6 +55,10 @@ impl SignedPublicKey {
             details,
             public_subkeys,
         }
+    }
+
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.details.expires_at(self.primary_key.created_at())
     }
 
     fn verify_public_subkeys(&self) -> Result<()> {
@@ -177,6 +182,7 @@ impl SignedPublicSubKey {
 
         Ok(())
     }
+
     pub fn as_unsigned(&self) -> PublicSubkey {
         let keyflags = self
             .signatures

--- a/src/composed/signed_key/secret.rs
+++ b/src/composed/signed_key/secret.rs
@@ -76,8 +76,10 @@ impl SignedSecretKey {
         }
     }
 
+    /// Get the secret key expiration as a date.
     pub fn expires_at(&self) -> Option<DateTime<Utc>> {
-        self.details.expires_at(self.primary_key.created_at())
+        let expiration = self.details.key_expiration_time()?;
+        Some(*self.primary_key.created_at() + expiration)
     }
 
     fn verify_public_subkeys(&self) -> Result<()> {

--- a/src/composed/signed_key/secret.rs
+++ b/src/composed/signed_key/secret.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io;
 
+use chrono::{DateTime, Utc};
 use rand::{CryptoRng, Rng};
 
 use crate::armor;
@@ -74,6 +75,11 @@ impl SignedSecretKey {
             secret_subkeys,
         }
     }
+
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.details.expires_at(self.primary_key.created_at())
+    }
+
     fn verify_public_subkeys(&self) -> Result<()> {
         for subkey in &self.public_subkeys {
             subkey.verify(&self.primary_key)?;

--- a/src/composed/signed_key/shared.rs
+++ b/src/composed/signed_key/shared.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::io;
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::Duration;
 use smallvec::SmallVec;
 
 use crate::composed::key::KeyDetails;
@@ -54,14 +54,14 @@ impl SignedKeyDetails {
         }
     }
 
-    /// Get the key expiration time.
+    /// Get the key expiration time as a duration.
     ///
     /// This method finds the signature with the maximum
     /// `KeyExpirationTime` offset (which should only occur in
-    /// self-signed signatures) and calculates the expiration time.
+    /// self-signed signatures) and converts it into a duration.
     /// The function returns `None` if the key has an infinite
     /// validity.
-    pub(crate) fn expires_at(&self, created_at: &DateTime<Utc>) -> Option<DateTime<Utc>> {
+    pub fn key_expiration_time(&self) -> Option<Duration> {
         // Find the maximum key_expiration_time in all signatures of all user ids.
         if let Some(tm) = self
             .users
@@ -70,9 +70,7 @@ impl SignedKeyDetails {
             .filter_map(|sig| sig.key_expiration_time())
             .max()
         {
-            let key_expiration = Duration::seconds(tm.timestamp());
-            let expires_at = *created_at + key_expiration;
-            Some(expires_at)
+            Some(Duration::seconds(tm.timestamp()))
         } else {
             None
         }


### PR DESCRIPTION
I'm missing a "simple" API to get the expiration date of a key, much like the `expires` or `expired` output of gpg:

```
pub   rsa4096 2014-10-14 [SCEA] [expired: 2018-09-15]
      XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
uid           [ expired] Test User <test@example.com>
```