### PR TITLE
docs: add a few doctests to showcase API usage 

### DIFF
--- a/src/armor/reader.rs
+++ b/src/armor/reader.rs
@@ -3,10 +3,9 @@ use std::hash::Hasher;
 use std::io::prelude::*;
 use std::{fmt, io, str};
 
-use base64;
 use buf_redux::BufReader;
 use byteorder::{BigEndian, ByteOrder};
-use crc24;
+
 use nom::{self, digit, line_ending, not_line_ending, InputIter, InputLength, Slice};
 
 use crate::base64_decoder::Base64Decoder;

--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -278,7 +278,6 @@ mod tests {
     use crate::composed::{Deserializable, SignedPublicKey, SignedSecretKey};
     use crate::types::SecretKeyTrait;
 
-    use pretty_env_logger;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
@@ -328,7 +327,6 @@ mod tests {
             .expect("failed to generate secret key, encrypted");
 
         let key_params_plain = key_params
-            .clone()
             .passphrase(None)
             .subkey(
                 SubkeyParamsBuilder::default()

--- a/src/composed/key/mod.rs
+++ b/src/composed/key/mod.rs
@@ -1,3 +1,133 @@
+//! Internal key definitions
+//!
+//! These APIs do not provide guaranteed RFC4880 compliance,
+//! since hashing is to be done externally.
+//!
+//!
+//! # A full sign-verify-round-trip example
+//!
+//! ```rust
+//! use pgp::composed::{KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
+//! use pgp::errors::Result;
+//! use pgp::packet::{KeyFlags, UserAttribute, UserId};
+//!	use pgp::types::{PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! use pgp::crypto::{sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
+//! use smallvec::*;
+//!
+//! let mut key_params = SecretKeyParamsBuilder::default();
+//! key_params
+//! .key_type(KeyType::Rsa(2048))
+//! .can_create_certificates(false)
+//! .can_sign(true)
+//! .primary_user_id("Me <me@example.com>".into())
+//! .preferred_symmetric_algorithms(smallvec![
+//! 	SymmetricKeyAlgorithm::AES256,
+//! ])
+//! .preferred_hash_algorithms(smallvec![
+//! 	HashAlgorithm::SHA2_256,
+//! ])
+//! .preferred_compression_algorithms(smallvec![
+//! 	CompressionAlgorithm::ZLIB,
+//! ]);
+//! let secret_key_params = key_params.build().expect("Must be able to create secret key params");
+//! let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
+//! let passwd_fn = || String::new();
+//! let signed_secret_key = secret_key.sign(passwd_fn).expect("Must be able to sign its own metadata");
+//! let public_key = signed_secret_key.public_key();
+//! ```
+//!
+//! using the keys, one can then move on and sign and verify a digest directly
+//!
+//! ```rust
+//! # const DATA :&'static [u8] = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+//! # use pgp::composed::{self, KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
+//! # use pgp::errors::Result;
+//! # use pgp::packet::{self, KeyFlags, UserAttribute, UserId};
+//! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
+//!	# use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! # use smallvec::*;
+//! #
+//! # let mut key_params = SecretKeyParamsBuilder::default();
+//! # key_params
+//! # .key_type(KeyType::Rsa(2048))
+//! # .can_create_certificates(false)
+//! # .can_sign(true)
+//! # .primary_user_id("Me <me@example.com>".into())
+//! # .preferred_symmetric_algorithms(smallvec![
+//! # 	SymmetricKeyAlgorithm::AES256,
+//! # ])
+//! # .preferred_hash_algorithms(smallvec![
+//! # 	HashAlgorithm::SHA2_256,
+//! # ])
+//! # .preferred_compression_algorithms(smallvec![
+//! # 	CompressionAlgorithm::ZLIB,
+//! # ]);
+//! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
+//! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
+//! # let passwd_fn = || String::new();
+//! # let signed_secret_key = secret_key.sign(passwd_fn).expect("Must be able to sign its own metadata");
+//! # let public_key = signed_secret_key.public_key();
+//! let signing_key = signed_secret_key;
+//! let verification_key = public_key;
+//!
+//! use crate::pgp::types::KeyTrait;
+//! use chrono;
+//! use std::io::Cursor;
+//!
+//! let now = chrono::Utc::now();
+//!
+//!	let passwd_fn = || String::new();
+//!
+//! // simulate a digest, make sure it is a compliant produce with RFC4880
+//! // i.e. depending on the version one needs a special suffix / prefix
+//! // and length encoding. The following is NOT compliant:
+//! use sha2::{Sha256, Digest};
+//!	let digest = {
+//! 	let mut hasher = Sha256::new();
+//!     hasher.input(DATA);
+//!     hasher.result()
+//! };
+//! let digest = digest.as_slice();
+//!
+//!	// creates the cryptographic core of the signature without any metadata
+//!	let signature = signing_key
+//!		.create_signature(passwd_fn, ::pgp::crypto::HashAlgorithm::SHA2_256, digest)
+//!		.expect("Failed to crate signature");
+//!
+//! // the signature can already be verified
+//!	verification_key
+//!		.verify_signature(HashAlgorithm::SHA2_256, digest, &signature)
+//!		.expect("Failed to validate signature");
+//!
+//! // wraps the signature in the apropriate package fmt ready to be serialized
+//!	let signature = ::pgp::Signature::new(
+//!		types::Version::Old,
+//!		packet::SignatureVersion::V4,
+//!		packet::SignatureType::Binary,
+//!		crypto::public_key::PublicKeyAlgorithm::RSA,
+//!		crypto::hash::HashAlgorithm::SHA2_256,
+//!		[digest[0], digest[1]],
+//!		signature,
+//!		vec![
+//!			pgp::packet::Subpacket::SignatureCreationTime(now),
+//!			pgp::packet::Subpacket::Issuer(signing_key.key_id()),
+//!		],
+//!		vec![],
+//!	);
+//!
+//! // sign and and write the package
+//!	let mut signature_bytes = Vec::with_capacity(1024);
+//!
+//!	let mut buff = Cursor::new(&mut signature_bytes);
+//!	::pgp::packet::write_packet(&mut buff, &signature).expect("Write must succeed");
+//!
+//!
+//!	let signature = signature.signature;
+//!	verification_key
+//!		.verify_signature(pgp::crypto::HashAlgorithm::SHA2_256, digest, &signature)
+//!		.expect("Verify must succeed");
+//!	```
+
 mod builder;
 mod public;
 mod secret;

--- a/src/composed/key/mod.rs
+++ b/src/composed/key/mod.rs
@@ -115,7 +115,7 @@
 //!		vec![],
 //!	);
 //!
-//! // sign and and write the package
+//! // sign and and write the package (the package written here is NOT rfc4880 compliant)
 //!	let mut signature_bytes = Vec::with_capacity(1024);
 //!
 //!	let mut buff = Cursor::new(&mut signature_bytes);

--- a/src/composed/key/mod.rs
+++ b/src/composed/key/mod.rs
@@ -4,7 +4,7 @@
 //! since hashing is to be done externally.
 //!
 //!
-//! # A full sign-verify-round-trip example
+//! # Generating a signed secret key and deriving a public key
 //!
 //! ```rust
 //! use pgp::composed::{KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
@@ -16,19 +16,19 @@
 //!
 //! let mut key_params = SecretKeyParamsBuilder::default();
 //! key_params
-//! .key_type(KeyType::Rsa(2048))
-//! .can_create_certificates(false)
-//! .can_sign(true)
-//! .primary_user_id("Me <me@example.com>".into())
-//! .preferred_symmetric_algorithms(smallvec![
-//!     SymmetricKeyAlgorithm::AES256,
-//! ])
-//! .preferred_hash_algorithms(smallvec![
-//!     HashAlgorithm::SHA2_256,
-//! ])
-//! .preferred_compression_algorithms(smallvec![
-//!     CompressionAlgorithm::ZLIB,
-//! ]);
+//! 	.key_type(KeyType::Rsa(2048))
+//! 	.can_create_certificates(false)
+//! 	.can_sign(true)
+//! 	.primary_user_id("Me <me@example.com>".into())
+//! 	.preferred_symmetric_algorithms(smallvec![
+//! 	    SymmetricKeyAlgorithm::AES256,
+//! 	])
+//! 	.preferred_hash_algorithms(smallvec![
+//! 	    HashAlgorithm::SHA2_256,
+//! 	])
+//! 	.preferred_compression_algorithms(smallvec![
+//! 	    CompressionAlgorithm::ZLIB,
+//! 	]);
 //! let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
 //! let passwd_fn = || String::new();
@@ -36,97 +36,11 @@
 //! let public_key = signed_secret_key.public_key();
 //! ```
 //!
-//! using the keys, one can then move on and sign and verify a digest directly
+//! [Packet based signing and verifying] as well as
+//! [signing and verifying with external hashing] are demoed seperately.
 //!
-//! ```rust
-//! # const DATA :&'static [u8] = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-//! # use pgp::composed::{self, KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
-//! # use pgp::errors::Result;
-//! # use pgp::packet::{self, KeyFlags, UserAttribute, UserId};
-//! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
-//! # use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
-//! # use smallvec::*;
-//! #
-//! # let mut key_params = SecretKeyParamsBuilder::default();
-//! # key_params
-//! # .key_type(KeyType::Rsa(2048))
-//! # .can_create_certificates(false)
-//! # .can_sign(true)
-//! # .primary_user_id("Me <me@example.com>".into())
-//! # .preferred_symmetric_algorithms(smallvec![
-//! #     SymmetricKeyAlgorithm::AES256,
-//! # ])
-//! # .preferred_hash_algorithms(smallvec![
-//! #     HashAlgorithm::SHA2_256,
-//! # ])
-//! # .preferred_compression_algorithms(smallvec![
-//! #     CompressionAlgorithm::ZLIB,
-//! # ]);
-//! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
-//! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
-//! # let passwd_fn = || String::new();
-//! # let signed_secret_key = secret_key.sign(passwd_fn).expect("Must be able to sign its own metadata");
-//! # let public_key = signed_secret_key.public_key();
-//! let signing_key = signed_secret_key;
-//! let verification_key = public_key;
-//!
-//! use crate::pgp::types::KeyTrait;
-//! use chrono;
-//! use std::io::Cursor;
-//!
-//! let now = chrono::Utc::now();
-//!
-//! let passwd_fn = || String::new();
-//!
-//! // simulate a digest, make sure it is a compliant produce with RFC4880
-//! // i.e. depending on the version one needs a special suffix / prefix
-//! // and length encoding. The following is NOT compliant:
-//! use sha2::{Sha256, Digest};
-//! let digest = {
-//!     let mut hasher = Sha256::new();
-//!     hasher.input(DATA);
-//!     hasher.result()
-//! };
-//! let digest = digest.as_slice();
-//!
-//! // creates the cryptographic core of the signature without any metadata
-//! let signature = signing_key
-//!     .create_signature(passwd_fn, ::pgp::crypto::HashAlgorithm::SHA2_256, digest)
-//!     .expect("Failed to crate signature");
-//!
-//! // the signature can already be verified
-//! verification_key
-//!     .verify_signature(HashAlgorithm::SHA2_256, digest, &signature)
-//!     .expect("Failed to validate signature");
-//!
-//! // wraps the signature in the apropriate package fmt ready to be serialized
-//! let signature = ::pgp::Signature::new(
-//!     types::Version::Old,
-//!     packet::SignatureVersion::V4,
-//!     packet::SignatureType::Binary,
-//!     crypto::public_key::PublicKeyAlgorithm::RSA,
-//!     crypto::hash::HashAlgorithm::SHA2_256,
-//!     [digest[0], digest[1]],
-//!     signature,
-//!     vec![
-//!         pgp::packet::Subpacket::SignatureCreationTime(now),
-//!         pgp::packet::Subpacket::Issuer(signing_key.key_id()),
-//!     ],
-//!     vec![],
-//! );
-//!
-//! // sign and and write the package (the package written here is NOT rfc4880 compliant)
-//! let mut signature_bytes = Vec::with_capacity(1024);
-//!
-//! let mut buff = Cursor::new(&mut signature_bytes);
-//! ::pgp::packet::write_packet(&mut buff, &signature).expect("Write must succeed");
-//!
-//!
-//! let signature = signature.signature;
-//! verification_key
-//!     .verify_signature(pgp::crypto::HashAlgorithm::SHA2_256, digest, &signature)
-//!     .expect("Verify must succeed");
-//! ```
+//! [Packet based signing and verifying]: super::super::packet
+//! [signing and verifying with external hashing]: super::signed_key
 
 mod builder;
 mod public;

--- a/src/composed/key/mod.rs
+++ b/src/composed/key/mod.rs
@@ -10,7 +10,7 @@
 //! use pgp::composed::{KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
 //! use pgp::errors::Result;
 //! use pgp::packet::{KeyFlags, UserAttribute, UserId};
-//!	use pgp::types::{PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! use pgp::types::{PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
 //! use pgp::crypto::{sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
 //! use smallvec::*;
 //!
@@ -21,13 +21,13 @@
 //! .can_sign(true)
 //! .primary_user_id("Me <me@example.com>".into())
 //! .preferred_symmetric_algorithms(smallvec![
-//! 	SymmetricKeyAlgorithm::AES256,
+//!     SymmetricKeyAlgorithm::AES256,
 //! ])
 //! .preferred_hash_algorithms(smallvec![
-//! 	HashAlgorithm::SHA2_256,
+//!     HashAlgorithm::SHA2_256,
 //! ])
 //! .preferred_compression_algorithms(smallvec![
-//! 	CompressionAlgorithm::ZLIB,
+//!     CompressionAlgorithm::ZLIB,
 //! ]);
 //! let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
@@ -44,7 +44,7 @@
 //! # use pgp::errors::Result;
 //! # use pgp::packet::{self, KeyFlags, UserAttribute, UserId};
 //! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
-//!	# use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! # use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
 //! # use smallvec::*;
 //! #
 //! # let mut key_params = SecretKeyParamsBuilder::default();
@@ -54,13 +54,13 @@
 //! # .can_sign(true)
 //! # .primary_user_id("Me <me@example.com>".into())
 //! # .preferred_symmetric_algorithms(smallvec![
-//! # 	SymmetricKeyAlgorithm::AES256,
+//! #     SymmetricKeyAlgorithm::AES256,
 //! # ])
 //! # .preferred_hash_algorithms(smallvec![
-//! # 	HashAlgorithm::SHA2_256,
+//! #     HashAlgorithm::SHA2_256,
 //! # ])
 //! # .preferred_compression_algorithms(smallvec![
-//! # 	CompressionAlgorithm::ZLIB,
+//! #     CompressionAlgorithm::ZLIB,
 //! # ]);
 //! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
@@ -76,57 +76,57 @@
 //!
 //! let now = chrono::Utc::now();
 //!
-//!	let passwd_fn = || String::new();
+//! let passwd_fn = || String::new();
 //!
 //! // simulate a digest, make sure it is a compliant produce with RFC4880
 //! // i.e. depending on the version one needs a special suffix / prefix
 //! // and length encoding. The following is NOT compliant:
 //! use sha2::{Sha256, Digest};
-//!	let digest = {
-//! 	let mut hasher = Sha256::new();
+//! let digest = {
+//!     let mut hasher = Sha256::new();
 //!     hasher.input(DATA);
 //!     hasher.result()
 //! };
 //! let digest = digest.as_slice();
 //!
-//!	// creates the cryptographic core of the signature without any metadata
-//!	let signature = signing_key
-//!		.create_signature(passwd_fn, ::pgp::crypto::HashAlgorithm::SHA2_256, digest)
-//!		.expect("Failed to crate signature");
+//! // creates the cryptographic core of the signature without any metadata
+//! let signature = signing_key
+//!     .create_signature(passwd_fn, ::pgp::crypto::HashAlgorithm::SHA2_256, digest)
+//!     .expect("Failed to crate signature");
 //!
 //! // the signature can already be verified
-//!	verification_key
-//!		.verify_signature(HashAlgorithm::SHA2_256, digest, &signature)
-//!		.expect("Failed to validate signature");
+//! verification_key
+//!     .verify_signature(HashAlgorithm::SHA2_256, digest, &signature)
+//!     .expect("Failed to validate signature");
 //!
 //! // wraps the signature in the apropriate package fmt ready to be serialized
-//!	let signature = ::pgp::Signature::new(
-//!		types::Version::Old,
-//!		packet::SignatureVersion::V4,
-//!		packet::SignatureType::Binary,
-//!		crypto::public_key::PublicKeyAlgorithm::RSA,
-//!		crypto::hash::HashAlgorithm::SHA2_256,
-//!		[digest[0], digest[1]],
-//!		signature,
-//!		vec![
-//!			pgp::packet::Subpacket::SignatureCreationTime(now),
-//!			pgp::packet::Subpacket::Issuer(signing_key.key_id()),
-//!		],
-//!		vec![],
-//!	);
+//! let signature = ::pgp::Signature::new(
+//!     types::Version::Old,
+//!     packet::SignatureVersion::V4,
+//!     packet::SignatureType::Binary,
+//!     crypto::public_key::PublicKeyAlgorithm::RSA,
+//!     crypto::hash::HashAlgorithm::SHA2_256,
+//!     [digest[0], digest[1]],
+//!     signature,
+//!     vec![
+//!         pgp::packet::Subpacket::SignatureCreationTime(now),
+//!         pgp::packet::Subpacket::Issuer(signing_key.key_id()),
+//!     ],
+//!     vec![],
+//! );
 //!
 //! // sign and and write the package (the package written here is NOT rfc4880 compliant)
-//!	let mut signature_bytes = Vec::with_capacity(1024);
+//! let mut signature_bytes = Vec::with_capacity(1024);
 //!
-//!	let mut buff = Cursor::new(&mut signature_bytes);
-//!	::pgp::packet::write_packet(&mut buff, &signature).expect("Write must succeed");
+//! let mut buff = Cursor::new(&mut signature_bytes);
+//! ::pgp::packet::write_packet(&mut buff, &signature).expect("Write must succeed");
 //!
 //!
-//!	let signature = signature.signature;
-//!	verification_key
-//!		.verify_signature(pgp::crypto::HashAlgorithm::SHA2_256, digest, &signature)
-//!		.expect("Verify must succeed");
-//!	```
+//! let signature = signature.signature;
+//! verification_key
+//!     .verify_signature(pgp::crypto::HashAlgorithm::SHA2_256, digest, &signature)
+//!     .expect("Verify must succeed");
+//! ```
 
 mod builder;
 mod public;

--- a/src/composed/key/mod.rs
+++ b/src/composed/key/mod.rs
@@ -16,19 +16,19 @@
 //!
 //! let mut key_params = SecretKeyParamsBuilder::default();
 //! key_params
-//! 	.key_type(KeyType::Rsa(2048))
-//! 	.can_create_certificates(false)
-//! 	.can_sign(true)
-//! 	.primary_user_id("Me <me@example.com>".into())
-//! 	.preferred_symmetric_algorithms(smallvec![
-//! 	    SymmetricKeyAlgorithm::AES256,
-//! 	])
-//! 	.preferred_hash_algorithms(smallvec![
-//! 	    HashAlgorithm::SHA2_256,
-//! 	])
-//! 	.preferred_compression_algorithms(smallvec![
-//! 	    CompressionAlgorithm::ZLIB,
-//! 	]);
+//!     .key_type(KeyType::Rsa(2048))
+//!     .can_create_certificates(false)
+//!     .can_sign(true)
+//!     .primary_user_id("Me <me@example.com>".into())
+//!     .preferred_symmetric_algorithms(smallvec![
+//!         SymmetricKeyAlgorithm::AES256,
+//!     ])
+//!     .preferred_hash_algorithms(smallvec![
+//!         HashAlgorithm::SHA2_256,
+//!     ])
+//!     .preferred_compression_algorithms(smallvec![
+//!         CompressionAlgorithm::ZLIB,
+//!     ]);
 //! let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
 //! let passwd_fn = || String::new();

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -773,7 +773,6 @@ mod tests {
 
     #[test]
     fn test_password_encryption() {
-        use pretty_env_logger;
         let _ = pretty_env_logger::try_init();
 
         let mut rng = thread_rng();

--- a/src/composed/signed_key/mod.rs
+++ b/src/composed/signed_key/mod.rs
@@ -96,7 +96,7 @@
 //!
 //! let mut buff = Cursor::new(&mut signature_bytes);
 //! packet::write_packet(&mut buff, &signature)
-//! 	.expect("Write must succeed");
+//!     .expect("Write must succeed");
 //!
 //!
 //! let raw_signature = signature.signature;

--- a/src/crypto/aes_kw.rs
+++ b/src/crypto/aes_kw.rs
@@ -1,4 +1,3 @@
-use aes;
 use aes::block_cipher_trait::generic_array::sequence::{Concat, Split};
 use aes::block_cipher_trait::generic_array::typenum::U8;
 use aes::block_cipher_trait::generic_array::GenericArray;
@@ -167,8 +166,6 @@ impl_aes_kw!(wrap_256, unwrap_256, 256, aes::Aes256);
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use hex;
 
     macro_rules! test_aes_kw {
         ($name:ident, $kek:expr, $input:expr, $output:expr) => {

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -8,8 +8,6 @@ use generic_array::typenum::Unsigned;
 use md5::Md5;
 use ripemd160::Ripemd160;
 use sha1::Sha1;
-use sha2;
-use sha3;
 
 use crate::errors::{Error, Result};
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,11 +1,6 @@
 use aes::block_cipher_trait;
-use base64;
-use block_modes;
-use block_padding;
-use cfb_mode;
+
 use ed25519_dalek::SignatureError;
-use nom;
-use rsa;
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
 //! # rPGP
 //!
 //! rPGP is an OpenPGP implementation.
+//!
+//! Usage examples are available under the respective modules:
+//! [Key generation], [signing and verifying with external hashing], [packet based signing and verifying].
+//!
+//! [Key generation]: crate::composed::key
+//! [signing and verifying with external hashing]: crate::composed::signed_key
+//! [packet based signing and verifying]: crate::packet
 
 #![deny(
     clippy::all,

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -1,6 +1,77 @@
 //! # Packet module
 //!
 //! This module handles everything in relationship to packets.
+//!
+//! ```rust
+//! # const DATA :&'static [u8] = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+//! # use pgp::composed::{self, KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
+//! # use pgp::errors::Result;
+//! # use pgp::packet::{self, KeyFlags, UserAttribute, UserId};
+//! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
+//!	# use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! # use smallvec::*;
+//! #
+//! # let mut key_params = SecretKeyParamsBuilder::default();
+//! # key_params
+//! # .key_type(KeyType::Rsa(2048))
+//! # .can_create_certificates(false)
+//! # .can_sign(true)
+//! # .primary_user_id("Me <me@example.com>".into())
+//! # .preferred_symmetric_algorithms(smallvec![
+//! # 	SymmetricKeyAlgorithm::AES256,
+//! # ])
+//! # .preferred_hash_algorithms(smallvec![
+//! # 	HashAlgorithm::SHA2_256,
+//! # ])
+//! # .preferred_compression_algorithms(smallvec![
+//! # 	CompressionAlgorithm::ZLIB,
+//! # ]);
+//! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
+//! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
+//! # let passwd_fn = || String::new();
+//! # let signed_secret_key = secret_key.sign(passwd_fn).expect("Must be able to sign its own metadata");
+//! # let public_key = signed_secret_key.public_key();
+//! use crate::pgp::types::KeyTrait;
+//!
+//! let signing_key = signed_secret_key;
+//! let verification_key = public_key;
+//!
+//!
+//! let passwd_fn = || String::new();
+//!
+//! let now = ::chrono::Utc::now();
+//!
+//! let mut sig_cfg_bldr = ::pgp::packet::SignatureConfigBuilder::default();
+//! let sig_cfg = sig_cfg_bldr
+//! 	.version(::pgp::packet::SignatureVersion::V4)
+//! 	.typ(::pgp::packet::SignatureType::Binary)
+//! 	.pub_alg(::pgp::crypto::public_key::PublicKeyAlgorithm::RSA)
+//! 	.hash_alg(::pgp::crypto::hash::HashAlgorithm::SHA2_256)
+//! 	.issuer(Some(signing_key.key_id()))
+//! 	.created(Some(now))
+//! 	.unhashed_subpackets(vec![]) // must be initialized
+//! 	.hashed_subpackets(vec![
+//! 		::pgp::packet::Subpacket::SignatureCreationTime(now),
+//! 		::pgp::packet::Subpacket::Issuer(signing_key.key_id()),
+//! 	]) // must be initialized
+//! 	.build()
+//! 	.unwrap();
+//!
+//! let signature_packet = sig_cfg
+//! 	.sign(&signing_key, passwd_fn, DATA)
+//! 	.expect("Should sign");
+//!
+//! let mut signature_bytes = Vec::with_capacity(1024);
+//!	let mut buff = std::io::Cursor::new(&mut signature_bytes);
+//!	::pgp::packet::write_packet(&mut buff, &signature_packet).expect("Write must succeed");
+//!
+//! signature_packet
+//! 	.verify(&verification_key, DATA)
+//! 	.expect("Failed to validate signature");
+//!
+//! ```
+
+
 
 mod many;
 mod packet_sum;

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -19,19 +19,19 @@
 //! #
 //! # let mut key_params = SecretKeyParamsBuilder::default();
 //! # key_params
-//! # 	.key_type(KeyType::Rsa(2048))
-//! # 	.can_create_certificates(false)
-//! # 	.can_sign(true)
-//! # 	.primary_user_id("Me <me@example.com>".into())
-//! # 	.preferred_symmetric_algorithms(smallvec![
-//! # 	     SymmetricKeyAlgorithm::AES256,
-//! # 	])
-//! # 	.preferred_hash_algorithms(smallvec![
-//! # 	     HashAlgorithm::SHA2_256,
-//! # 	])
-//! # 	.preferred_compression_algorithms(smallvec![
-//! # 	     CompressionAlgorithm::ZLIB,
-//! # 	]);
+//! #     .key_type(KeyType::Rsa(2048))
+//! #     .can_create_certificates(false)
+//! #     .can_sign(true)
+//! #     .primary_user_id("Me <me@example.com>".into())
+//! #     .preferred_symmetric_algorithms(smallvec![
+//! #          SymmetricKeyAlgorithm::AES256,
+//! #     ])
+//! #     .preferred_hash_algorithms(smallvec![
+//! #          HashAlgorithm::SHA2_256,
+//! #     ])
+//! #     .preferred_compression_algorithms(smallvec![
+//! #          CompressionAlgorithm::ZLIB,
+//! #     ]);
 //! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
 //! # let passwd_fn = || String::new();

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -8,7 +8,7 @@
 //! # use pgp::errors::Result;
 //! # use pgp::packet::{self, KeyFlags, UserAttribute, UserId};
 //! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
-//!	# use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! # use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
 //! # use smallvec::*;
 //! #
 //! # let mut key_params = SecretKeyParamsBuilder::default();
@@ -18,13 +18,13 @@
 //! # .can_sign(true)
 //! # .primary_user_id("Me <me@example.com>".into())
 //! # .preferred_symmetric_algorithms(smallvec![
-//! # 	SymmetricKeyAlgorithm::AES256,
+//! #      SymmetricKeyAlgorithm::AES256,
 //! # ])
 //! # .preferred_hash_algorithms(smallvec![
-//! # 	HashAlgorithm::SHA2_256,
+//! #      HashAlgorithm::SHA2_256,
 //! # ])
 //! # .preferred_compression_algorithms(smallvec![
-//! # 	CompressionAlgorithm::ZLIB,
+//! #      CompressionAlgorithm::ZLIB,
 //! # ]);
 //! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
@@ -43,31 +43,31 @@
 //!
 //! let mut sig_cfg_bldr = ::pgp::packet::SignatureConfigBuilder::default();
 //! let sig_cfg = sig_cfg_bldr
-//! 	.version(::pgp::packet::SignatureVersion::V4)
-//! 	.typ(::pgp::packet::SignatureType::Binary)
-//! 	.pub_alg(::pgp::crypto::public_key::PublicKeyAlgorithm::RSA)
-//! 	.hash_alg(::pgp::crypto::hash::HashAlgorithm::SHA2_256)
-//! 	.issuer(Some(signing_key.key_id()))
-//! 	.created(Some(now))
-//! 	.unhashed_subpackets(vec![]) // must be initialized
-//! 	.hashed_subpackets(vec![
-//! 		::pgp::packet::Subpacket::SignatureCreationTime(now),
-//! 		::pgp::packet::Subpacket::Issuer(signing_key.key_id()),
-//! 	]) // must be initialized
-//! 	.build()
-//! 	.unwrap();
+//!      .version(::pgp::packet::SignatureVersion::V4)
+//!      .typ(::pgp::packet::SignatureType::Binary)
+//!      .pub_alg(::pgp::crypto::public_key::PublicKeyAlgorithm::RSA)
+//!      .hash_alg(::pgp::crypto::hash::HashAlgorithm::SHA2_256)
+//!      .issuer(Some(signing_key.key_id()))
+//!      .created(Some(now))
+//!      .unhashed_subpackets(vec![]) // must be initialized
+//!      .hashed_subpackets(vec![
+//!           ::pgp::packet::Subpacket::SignatureCreationTime(now),
+//!           ::pgp::packet::Subpacket::Issuer(signing_key.key_id()),
+//!      ]) // must be initialized
+//!      .build()
+//!      .unwrap();
 //!
 //! let signature_packet = sig_cfg
-//! 	.sign(&signing_key, passwd_fn, DATA)
-//! 	.expect("Should sign");
+//!      .sign(&signing_key, passwd_fn, DATA)
+//!      .expect("Should sign");
 //!
 //! let mut signature_bytes = Vec::with_capacity(1024);
-//!	let mut buff = std::io::Cursor::new(&mut signature_bytes);
-//!	::pgp::packet::write_packet(&mut buff, &signature_packet).expect("Write must succeed");
+//!     let mut buff = std::io::Cursor::new(&mut signature_bytes);
+//!     ::pgp::packet::write_packet(&mut buff, &signature_packet).expect("Write must succeed");
 //!
 //! signature_packet
-//! 	.verify(&verification_key, DATA)
-//! 	.expect("Failed to validate signature");
+//!      .verify(&verification_key, DATA)
+//!      .expect("Failed to validate signature");
 //!
 //! ```
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -71,8 +71,6 @@
 //!
 //! ```
 
-
-
 mod many;
 mod packet_sum;
 mod single;

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -1,37 +1,44 @@
 //! # Packet module
 //!
-//! This module handles everything in relationship to packets.
+//! Handles everything in relationship to packets.
+//!
+//! [`Key generation`] is handled seperately as well as
+//! [`signing and verifying with external hashing`] applied.
+//!
+//! [`Key generation`]: super::composed::key
+//! [`signing and verifying with external hashing`]: super::composed::signed_key
 //!
 //! ```rust
-//! # const DATA :&'static [u8] = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+//! # const DATA :&'static [u8] = b"Hello World";
 //! # use pgp::composed::{self, KeyType, KeyDetails, SecretKey, SecretSubkey, key::SecretKeyParamsBuilder};
 //! # use pgp::errors::Result;
 //! # use pgp::packet::{self, KeyFlags, UserAttribute, UserId};
-//! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm};
-//! # use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
-//! # use smallvec::*;
+//! use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm, public_key::PublicKeyAlgorithm};
+//! use pgp::types::{self, PublicKeyTrait, SecretKeyTrait, CompressionAlgorithm};
+//! use smallvec::*;
 //! #
 //! # let mut key_params = SecretKeyParamsBuilder::default();
 //! # key_params
-//! # .key_type(KeyType::Rsa(2048))
-//! # .can_create_certificates(false)
-//! # .can_sign(true)
-//! # .primary_user_id("Me <me@example.com>".into())
-//! # .preferred_symmetric_algorithms(smallvec![
-//! #      SymmetricKeyAlgorithm::AES256,
-//! # ])
-//! # .preferred_hash_algorithms(smallvec![
-//! #      HashAlgorithm::SHA2_256,
-//! # ])
-//! # .preferred_compression_algorithms(smallvec![
-//! #      CompressionAlgorithm::ZLIB,
-//! # ]);
+//! # 	.key_type(KeyType::Rsa(2048))
+//! # 	.can_create_certificates(false)
+//! # 	.can_sign(true)
+//! # 	.primary_user_id("Me <me@example.com>".into())
+//! # 	.preferred_symmetric_algorithms(smallvec![
+//! # 	     SymmetricKeyAlgorithm::AES256,
+//! # 	])
+//! # 	.preferred_hash_algorithms(smallvec![
+//! # 	     HashAlgorithm::SHA2_256,
+//! # 	])
+//! # 	.preferred_compression_algorithms(smallvec![
+//! # 	     CompressionAlgorithm::ZLIB,
+//! # 	]);
 //! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
 //! # let secret_key = secret_key_params.generate().expect("Failed to generate a plain key.");
 //! # let passwd_fn = || String::new();
 //! # let signed_secret_key = secret_key.sign(passwd_fn).expect("Must be able to sign its own metadata");
 //! # let public_key = signed_secret_key.public_key();
-//! use crate::pgp::types::KeyTrait;
+//! use pgp::types::KeyTrait;
+//! use pgp::packet::{SignatureConfigBuilder, Signature};
 //!
 //! let signing_key = signed_secret_key;
 //! let verification_key = public_key;
@@ -39,20 +46,20 @@
 //!
 //! let passwd_fn = || String::new();
 //!
-//! let now = ::chrono::Utc::now();
+//! let now = chrono::Utc::now();
 //!
-//! let mut sig_cfg_bldr = ::pgp::packet::SignatureConfigBuilder::default();
+//! let mut sig_cfg_bldr = SignatureConfigBuilder::default();
 //! let sig_cfg = sig_cfg_bldr
-//!      .version(::pgp::packet::SignatureVersion::V4)
-//!      .typ(::pgp::packet::SignatureType::Binary)
-//!      .pub_alg(::pgp::crypto::public_key::PublicKeyAlgorithm::RSA)
-//!      .hash_alg(::pgp::crypto::hash::HashAlgorithm::SHA2_256)
+//!      .version(packet::SignatureVersion::V4)
+//!      .typ(packet::SignatureType::Binary)
+//!      .pub_alg(PublicKeyAlgorithm::RSA)
+//!      .hash_alg(HashAlgorithm::SHA2_256)
 //!      .issuer(Some(signing_key.key_id()))
 //!      .created(Some(now))
 //!      .unhashed_subpackets(vec![]) // must be initialized
 //!      .hashed_subpackets(vec![
-//!           ::pgp::packet::Subpacket::SignatureCreationTime(now),
-//!           ::pgp::packet::Subpacket::Issuer(signing_key.key_id()),
+//!           packet::Subpacket::SignatureCreationTime(now),
+//!           packet::Subpacket::Issuer(signing_key.key_id()),
 //!      ]) // must be initialized
 //!      .build()
 //!      .unwrap();
@@ -63,7 +70,7 @@
 //!
 //! let mut signature_bytes = Vec::with_capacity(1024);
 //!     let mut buff = std::io::Cursor::new(&mut signature_bytes);
-//!     ::pgp::packet::write_packet(&mut buff, &signature_packet).expect("Write must succeed");
+//!     packet::write_packet(&mut buff, &signature_packet).expect("Write must succeed");
 //!
 //! signature_packet
 //!      .verify(&verification_key, DATA)

--- a/src/types/key_id.rs
+++ b/src/types/key_id.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use crate::errors::Result;
-use hex;
 
 /// Represents a Key ID.
 #[derive(Clone, Eq, PartialEq)]

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -130,7 +130,6 @@ parse_dumps!(
 
 #[test]
 fn test_parse_gnupg_v1() {
-    use pretty_env_logger;
     let _ = pretty_env_logger::try_init();
 
     for i in 1..5 {
@@ -222,7 +221,6 @@ fn test_parse_openpgp_sample_rsa_private() {
 
 #[test]
 fn test_parse_details() {
-    use pretty_env_logger;
     let _ = pretty_env_logger::try_init();
 
     let file = File::open("./tests/opengpg-interop/testcases/keys/gnupg-v1-003.asc").unwrap();
@@ -487,14 +485,14 @@ fn test_parse_details() {
                     .expect("failed to parse static time")
                     .with_timezone(&Utc),
             ),
-            Subpacket::KeyFlags(key_flags.clone()),
-            Subpacket::PreferredSymmetricAlgorithms(p_sym_algs.clone()),
-            Subpacket::PreferredHashAlgorithms(p_hash_algs.clone()),
-            Subpacket::PreferredCompressionAlgorithms(p_com_algs.clone()),
+            Subpacket::KeyFlags(key_flags),
+            Subpacket::PreferredSymmetricAlgorithms(p_sym_algs),
+            Subpacket::PreferredHashAlgorithms(p_hash_algs),
+            Subpacket::PreferredCompressionAlgorithms(p_com_algs),
             Subpacket::Features(smallvec![1]),
             Subpacket::KeyServerPreferences(smallvec![128]),
         ],
-        vec![issuer.clone()],
+        vec![issuer],
     );
 
     assert_eq!(ua.signatures, vec![sig3]);
@@ -964,7 +962,6 @@ fn test_invalid() {
 
 #[test]
 fn test_handle_incomplete_packets_end() {
-    use pretty_env_logger;
     let _ = pretty_env_logger::try_init();
     let p = Path::new("./tests/opengpg-interop/testcases/messages/gnupg-v1-001-decrypt.asc");
     let mut file = read_file(p.to_path_buf());

--- a/tests/message_test.rs
+++ b/tests/message_test.rs
@@ -249,7 +249,6 @@ fn msg_regression_01() {
 
 #[test]
 fn msg_large_indeterminate_len() {
-    use pretty_env_logger;
     let _ = pretty_env_logger::try_init();
 
     let mut msg_file = File::open("./tests/indeterminated.asc").unwrap();


### PR DESCRIPTION
Goal: show basic usage in module docs
* [x] core signing / verification usage for generic (non rfc4880 specific) API
* [x] PGP rfc4880 compliant API
* [x] make 'em ~pretty~ decent

Ref #96