### PR TITLE
Required updates due to ed25519-dalek moving to v1.0.0-pre.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,57 +16,51 @@ exclude = ["tests/tests/*"]
 edition = "2018"
 
 [dependencies]
-crc24 = "^0.1"
-base64 = "^0.12.0"
-byteorder = "^1.2"
-chrono = "^0.4"
-circular = "^0.3"
-sha-1 = "^0.9"
-sha2 = "^0.9"
-md-5 = "^0.9"
-ripemd160 = "^0.9"
-generic-array = "^0.14"
-digest = "^0.9"
 aes = "^0.4"
-blowfish = "^0.5"
-twofish = "^0.3"
-des = "^0.4"
+base64 = "^0.12.0"
+bitfield = "0.13.1"
 block-modes = "^0.4"
-hex = "^0.4"
+block-padding = "0.2.0"
+blowfish = "^0.5"
+byteorder = "^1.2"
+cast5 = "0.7.0"
+chrono = "^0.4"
 cfb-mode = "^0.4.0"
+circular = "^0.3"
+clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
+crc24 = "^0.1"
+derive_builder = "0.9.0"
+des = "^0.4"
+digest = "^0.9"
+generic-array = "^0.14"
+hex = "^0.4"
+lazy_static = "1.2.0"
+log = "0.4.6"
+md-5 = "^0.9"
+nom = "^4.2"
 num-derive = "0.3.0"
 num-traits = "0.2.6"
-lazy_static = "1.2.0"
-block-padding = "0.2.0"
-log = "0.4.6"
-try_from = "^0.3"
-derive_builder = "0.9.0"
-bitfield = "0.13.1"
-sha3 = "0.9"
 rand = "0.7"
-smallvec = "1.0.0"
-cast5 = "0.7.0"
+ripemd160 = "^0.9"
 rsa = "^0.3.0"
-nom = "^4.2"
-zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
-clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
-thiserror = "1.0.9"
+sha-1 = "^0.9"
+sha2 = "^0.9"
+sha3 = "0.9"
 signature = "1.1"
+smallvec = "1.0.0"
+thiserror = "1.0.9"
+try_from = "^0.3"
+twofish = "^0.3"
+zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 
-[dependencies.x25519-dalek]
-version = "0.6"
+[dependencies.buf_redux]
+version = "0.8.1"
 default-features = false
-features = ["std", "u64_backend"]
 
 [dependencies.ed25519-dalek]
 version = "1.0.0-pre.4"
 default-features = false
 features = ["std", "u64_backend"]
-
-[dependencies.num-bigint]
-version = "0.6"
-features = ["rand", "i128", "u64_digit", "prime", "zeroize"]
-package = "num-bigint-dig"
 
 [dependencies.flate2]
 version = "^1.0"
@@ -77,20 +71,26 @@ features = ["rust_backend"]
 version = "0.2.0"
 optional = true
 
-[dependencies.buf_redux]
-version = "0.8.1"
+[dependencies.num-bigint]
+version = "0.6"
+features = ["rand", "i128", "u64_digit", "prime", "zeroize"]
+package = "num-bigint-dig"
+
+[dependencies.x25519-dalek]
+version = "0.6"
 default-features = false
+features = ["std", "u64_backend"]
 
 [dev-dependencies]
+glob = "^0.3"
 hex-literal = "^0.2"
+pretty_assertions = "0.6"
+pretty_env_logger = "0.3"
+rand_chacha = "0.2"
+rand_xorshift = "0.2"
+regex = "^1.1"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-glob = "^0.3"
-regex = "^1.1"
-pretty_assertions = "0.6"
-rand_xorshift = "0.2"
-rand_chacha = "0.2"
-pretty_env_logger = "0.3"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ nom = "^4.2"
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 thiserror = "1.0.9"
+signature = "1.1"
 
 [dependencies.x25519-dalek]
 version = "0.6"
@@ -58,7 +59,7 @@ default-features = false
 features = ["std", "u64_backend"]
 
 [dependencies.ed25519-dalek]
-version = "1.0.0-pre.3"
+version = "1.0.0-pre.4"
 default-features = false
 features = ["std", "u64_backend"]
 

--- a/src/crypto/eddsa.rs
+++ b/src/crypto/eddsa.rs
@@ -1,5 +1,6 @@
 use ed25519_dalek::Keypair;
 use rand::{CryptoRng, Rng};
+use signature::{Signature, Signer, Verifier};
 use zeroize::Zeroize;
 
 use crate::crypto::{ECCCurve, HashAlgorithm};


### PR DESCRIPTION
Fixes #103.

Since `ed25519-dalek` moved to `v1.0.0-pre.4` (from `v1.0.0-pre.3`) approximately 15 hours ago, pgp no longer builds due to a change in the `ed25519-dalek` API.

The fix involves:

* Using the following now required traits in `src/crypto/eddsa.rs`: `signature::{Signature, Signer, Verifier}`
* Bringing in the signature crate as an explicit dependency (as this is where the above traits are exported)
