### PR TITLE
Fix ISA build versions specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ No critical flaws were found. We have fixed and are fixing some high, medium and
 low risk ones. We will soon publish the full review report.
 Further independent security reviews are upcoming.
 
-rPGP is used in production by [Delta Chat, the e-mail based messenger app suite](https://delta.chat), successfully running on Windows, Linux, macOS, Android and iOS in 32bit and 64 bit builds.
+rPGP is used in production by [Delta Chat, the e-mail based messenger app suite](https://delta.chat), successfully running on Windows, Linux, macOS, Android and iOS in 32bit (only Windows and Android) and 64 bit builds (for the other platforms).
 
 More details on platform and OpenPGP implementation status: 
 


### PR DESCRIPTION
Android and Windows are the only platforms with 32 bits support for ARM and x86 being Windows fully 32 bits (x86_32) and in Android depending on the ISA. This is because of client framework limitations (Electron for desktop) and the state of some OS (iOS, Android, etc in their native platforms) but not the core itself.