### PR TITLE
Make signature field of StandaloneSignature public

### DIFF
--- a/src/composed/signature.rs
+++ b/src/composed/signature.rs
@@ -14,7 +14,7 @@ use crate::types::Tag;
 /// Standalone signature as defined by the cleartext framework.
 #[derive(Debug, Clone)]
 pub struct StandaloneSignature {
-    signature: Signature,
+    pub signature: Signature,
 }
 
 impl StandaloneSignature {


### PR DESCRIPTION
This is consistent with many other structs defined in rpgp, and it's
hard to do basic things such inspecting details of the signature
otherwise.