### PR TITLE
Fix corruption of non-ascii characters in text literals

### DIFF
--- a/src/packet/literal_data.rs
+++ b/src/packet/literal_data.rs
@@ -142,3 +142,10 @@ impl fmt::Debug for LiteralData {
             .finish()
     }
 }
+
+#[test]
+fn test_utf8_literal() {
+    let slogan = "一门赋予每个人构建可靠且高效软件能力的语言。";
+    let literal = LiteralData::from_str("", &slogan);
+    assert!(String::from_utf8(literal.data).unwrap() == slogan);
+}

--- a/src/packet/literal_data.rs
+++ b/src/packet/literal_data.rs
@@ -38,9 +38,7 @@ pub enum DataMode {
 impl LiteralData {
     /// Creates a literal data packet from the given string. Normalizes line endings.
     pub fn from_str(file_name: &str, raw_data: &str) -> Self {
-        let data = Normalized::new(raw_data.chars(), LineBreak::Crlf)
-            .map(|c| c as u8)
-            .collect();
+        let data = Normalized::new(raw_data.bytes(), LineBreak::Crlf).collect();
 
         LiteralData {
             packet_version: Version::New,


### PR DESCRIPTION
First commit adds a test revealing the bug.

Second commit fixes the problem by making `normalize_lines..rs` work on bytes instead of chars.

This simplifies the code and it should be faster as well.