### PR TITLE
Add a method to construct a PublicKey from parameters.

### DIFF
--- a/src/packet/public_key_macro.rs
+++ b/src/packet/public_key_macro.rs
@@ -12,6 +12,45 @@ macro_rules! impl_public_key {
         }
 
         impl $name {
+            /// Create a new `PublicKeyKey` packet from underlying parameters.
+            pub fn new(
+                packet_version: $crate::types::Version,
+                version: $crate::types::KeyVersion,
+                created_at: chrono::DateTime<chrono::Utc>,
+                expiration: Option<u16>,
+                public_params: $crate::types::PublicParams,
+            ) -> Self {
+                let algorithm = match public_params {
+                    $crate::types::PublicParams::RSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::RSA
+                    }
+                    $crate::types::PublicParams::DSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::DSA
+                    }
+                    $crate::types::PublicParams::ECDSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDSA
+                    }
+                    $crate::types::PublicParams::ECDH { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDH
+                    }
+                    $crate::types::PublicParams::Elgamal { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::Elgamal
+                    }
+                    $crate::types::PublicParams::EdDSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::EdDSA
+                    }
+                };
+
+                $name {
+                    packet_version,
+                    version,
+                    algorithm,
+                    created_at,
+                    expiration,
+                    public_params,
+                }
+            }
+
             /// Parses a `PublicKeyKey` packet from the given slice.
             pub fn from_slice(
                 packet_version: $crate::types::Version,
@@ -42,42 +81,6 @@ macro_rules! impl_public_key {
                     expiration,
                     public_params,
                 })
-            }
-
-            pub fn from_params(
-                public_params: $crate::types::PublicParams,
-                created_at: chrono::DateTime<chrono::Utc>,
-                expiration: Option<u16>,
-            ) -> Self {
-                let algorithm = match public_params {
-                    $crate::types::PublicParams::RSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::RSA
-                    }
-                    $crate::types::PublicParams::DSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::DSA
-                    }
-                    $crate::types::PublicParams::ECDSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDSA
-                    }
-                    $crate::types::PublicParams::ECDH { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDH
-                    }
-                    $crate::types::PublicParams::Elgamal { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::Elgamal
-                    }
-                    $crate::types::PublicParams::EdDSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::EdDSA
-                    }
-                };
-
-                $name {
-                    packet_version: $crate::types::Version::Old,
-                    version: $crate::types::KeyVersion::V4,
-                    algorithm,
-                    created_at,
-                    expiration,
-                    public_params,
-                }
             }
 
             pub fn version(&self) -> $crate::types::KeyVersion {

--- a/src/packet/public_key_macro.rs
+++ b/src/packet/public_key_macro.rs
@@ -16,51 +16,13 @@ macro_rules! impl_public_key {
             pub fn new(
                 packet_version: $crate::types::Version,
                 version: $crate::types::KeyVersion,
+                algorithm: $crate::crypto::public_key::PublicKeyAlgorithm,
                 created_at: chrono::DateTime<chrono::Utc>,
                 expiration: Option<u16>,
                 public_params: $crate::types::PublicParams,
-            ) -> Self {
-                let algorithm = match public_params {
-                    $crate::types::PublicParams::RSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::RSA
-                    }
-                    $crate::types::PublicParams::DSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::DSA
-                    }
-                    $crate::types::PublicParams::ECDSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDSA
-                    }
-                    $crate::types::PublicParams::ECDH { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDH
-                    }
-                    $crate::types::PublicParams::Elgamal { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::Elgamal
-                    }
-                    $crate::types::PublicParams::EdDSA { .. } => {
-                        $crate::crypto::public_key::PublicKeyAlgorithm::EdDSA
-                    }
-                };
-
-                $name {
-                    packet_version,
-                    version,
-                    algorithm,
-                    created_at,
-                    expiration,
-                    public_params,
-                }
-            }
-
-            /// Parses a `PublicKeyKey` packet from the given slice.
-            pub fn from_slice(
-                packet_version: $crate::types::Version,
-                input: &[u8],
             ) -> $crate::errors::Result<Self> {
                 use $crate::crypto::PublicKeyAlgorithm;
                 use $crate::types::KeyVersion;
-
-                let (_, details) = $crate::packet::public_key_parser::parse(input)?;
-                let (version, algorithm, created_at, expiration, public_params) = details;
 
                 if version == KeyVersion::V2 || version == KeyVersion::V3 {
                     ensure!(
@@ -81,6 +43,24 @@ macro_rules! impl_public_key {
                     expiration,
                     public_params,
                 })
+            }
+
+            /// Parses a `PublicKeyKey` packet from the given slice.
+            pub fn from_slice(
+                packet_version: $crate::types::Version,
+                input: &[u8],
+            ) -> $crate::errors::Result<Self> {
+                let (_, details) = $crate::packet::public_key_parser::parse(input)?;
+                let (version, algorithm, created_at, expiration, public_params) = details;
+
+                $name::new(
+                    packet_version,
+                    version,
+                    algorithm,
+                    created_at,
+                    expiration,
+                    public_params,
+                )
             }
 
             pub fn version(&self) -> $crate::types::KeyVersion {

--- a/src/packet/public_key_macro.rs
+++ b/src/packet/public_key_macro.rs
@@ -44,6 +44,42 @@ macro_rules! impl_public_key {
                 })
             }
 
+            pub fn from_params(
+                public_params: $crate::types::PublicParams,
+                created_at: chrono::DateTime<chrono::Utc>,
+                expiration: Option<u16>,
+            ) -> Self {
+                let algorithm = match public_params {
+                    $crate::types::PublicParams::RSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::RSA
+                    }
+                    $crate::types::PublicParams::DSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::DSA
+                    }
+                    $crate::types::PublicParams::ECDSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDSA
+                    }
+                    $crate::types::PublicParams::ECDH { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::ECDH
+                    }
+                    $crate::types::PublicParams::Elgamal { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::Elgamal
+                    }
+                    $crate::types::PublicParams::EdDSA { .. } => {
+                        $crate::crypto::public_key::PublicKeyAlgorithm::EdDSA
+                    }
+                };
+
+                $name {
+                    packet_version: $crate::types::Version::Old,
+                    version: $crate::types::KeyVersion::V4,
+                    algorithm,
+                    created_at,
+                    expiration,
+                    public_params,
+                }
+            }
+
             pub fn version(&self) -> $crate::types::KeyVersion {
                 self.version
             }


### PR DESCRIPTION
Currently the only way to create a PublicKey is to have a pre-existing packet or to generate a new SecretKey and get it from there. This change adds a method that allows PublicKey objects to be synthesised from data from other sources, for example external key material.