### PR TITLE
Replace try_from dependency with std::convert::Try{From,Into}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ sha3 = "0.9"
 signature = "1.3.0"
 smallvec = "1.6.1"
 thiserror = "1.0.9"
-try_from = "^0.3"
 twofish = "^0.6"
 zeroize = { version = "~1.4.0", features = ["zeroize_derive"] }
 getrandom = { version = "0.2.3", optional = true }

--- a/src/composed/message/parser.rs
+++ b/src/composed/message/parser.rs
@@ -1,7 +1,6 @@
 use std::boxed::Box;
+use std::convert::TryInto;
 use std::iter::Peekable;
-
-use try_from::TryInto;
 
 use crate::composed::message::Message;
 use crate::composed::Deserializable;

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -1,5 +1,6 @@
 use std::boxed::Box;
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 use std::io;
 
 use chrono::{self, SubsecRound};
@@ -7,7 +8,6 @@ use flate2::write::{DeflateEncoder, ZlibEncoder};
 use flate2::Compression;
 use rand::{CryptoRng, Rng};
 use smallvec::SmallVec;
-use try_from::TryFrom;
 
 use crate::armor;
 use crate::composed::message::decrypt::*;
@@ -81,7 +81,7 @@ impl Esk {
 }
 
 impl TryFrom<Packet> for Esk {
-    type Err = Error;
+    type Error = Error;
 
     fn try_from(other: Packet) -> Result<Esk> {
         match other {
@@ -126,7 +126,7 @@ impl_try_from_into!(
 );
 
 impl TryFrom<Packet> for Edata {
-    type Err = Error;
+    type Error = Error;
 
     fn try_from(other: Packet) -> Result<Edata> {
         match other {

--- a/src/composed/signature.rs
+++ b/src/composed/signature.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
+use std::convert::TryInto;
 use std::iter::Peekable;
-
-use try_from::TryInto;
 
 use crate::armor;
 use crate::composed::Deserializable;

--- a/src/composed/signed_key/key_parser_macros.rs
+++ b/src/composed/signed_key/key_parser_macros.rs
@@ -13,7 +13,7 @@ macro_rules! key_parser {
             type Item = $crate::errors::Result<$key_type>;
 
             fn next(&mut self) -> Option<Self::Item> {
-                use try_from::TryInto;
+                use std::convert::TryInto;
                 use $crate::packet::{self, Signature, SignatureType, UserAttribute, UserId};
                 use $crate::types::{KeyVersion, SignedUser, SignedUserAttribute, Tag, KeyTrait};
 

--- a/src/crypto/eddsa.rs
+++ b/src/crypto/eddsa.rs
@@ -1,6 +1,6 @@
 use ed25519_dalek::Keypair;
 use rand::{CryptoRng, Rng};
-use signature::{Signature, Signer, Verifier};
+use signature::{Signer, Verifier};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::crypto::{ECCCurve, HashAlgorithm};

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -1,7 +1,7 @@
 use std::boxed::Box;
+use std::convert::TryInto;
 
 use rsa::Hash;
-use try_from::TryInto;
 
 use digest::{Digest, FixedOutput};
 use generic_array::typenum::Unsigned;
@@ -40,7 +40,7 @@ impl Default for HashAlgorithm {
 }
 
 impl TryInto<Hash> for HashAlgorithm {
-    type Err = Error;
+    type Error = Error;
 
     fn try_into(self) -> Result<Hash> {
         match self {

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -1,9 +1,10 @@
+use std::convert::TryInto;
+
 use num_bigint::traits::ModInverse;
 use num_bigint::BigUint;
 use rand::{CryptoRng, Rng};
 use rsa::padding::PaddingScheme;
 use rsa::{PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
-use try_from::TryInto;
 
 use crate::crypto::HashAlgorithm;
 use crate::errors::Result;

--- a/src/util.rs
+++ b/src/util.rs
@@ -161,11 +161,11 @@ where
 macro_rules! impl_try_from_into {
     ($enum_name:ident, $( $name:ident => $variant_type:ty ),*) => {
        $(
-           impl try_from::TryFrom<$enum_name> for $variant_type {
+           impl std::convert::TryFrom<$enum_name> for $variant_type {
                // TODO: Proper error
-               type Err = $crate::errors::Error;
+               type Error = $crate::errors::Error;
 
-               fn try_from(other: $enum_name) -> ::std::result::Result<$variant_type, Self::Err> {
+               fn try_from(other: $enum_name) -> ::std::result::Result<$variant_type, Self::Error> {
                    if let $enum_name::$name(value) = other {
                        Ok(value)
                    } else {


### PR DESCRIPTION
std::convert::TryFrom is already used in src/line_reader.rs and has
been available since Rust 1.34:
https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#tryfrom-and-tryinto