### PR TITLE
Derive Clone on hasher types

### DIFF
--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -70,7 +70,7 @@ pub trait Hasher: std::io::Write {
 
 macro_rules! derive_hasher {
     ($name:ident, $struct:path) => {
-        #[derive(Default)]
+        #[derive(Clone, Default)]
         pub struct $name {
             inner: $struct,
         }


### PR DESCRIPTION
I'm implementing cleartext signature verification using this crate
(I may contribute the code upstream once I have it working). A
problem I ran into is that as part of signature verification you
need to feed signature state into the hasher (which was already fed
the cleartext being verified). This means that you either need to
rehash the cleartext for each signature or maintain a per-signature
hasher. Both of these solutions are inefficient.

The hasher types used by this crate implement Clone. This means you
can have a single per-algorithm hasher then clone it before feeding
in signature state so you don't taint the hasher and can reuse it
for other signatures. However, because this crate's wrapper types
don't implement Clone, this optimization isn't available.

This commit implements Clone on this crate's hasher wrappers to
enable this optimization.

We may need to extend the Hasher trait with a clone-like function
to make this fully work. But I figured I'd test the waters by doing
making a hopefully non-controversial change first!