### PR TITLE
Avoid some allocations via to_string

### DIFF
--- a/src/base64_decoder.rs
+++ b/src/base64_decoder.rs
@@ -28,7 +28,7 @@ impl<R> fmt::Debug for Base64Decoder<R> {
         let out_buf = format!("{:?}", &self.out_buffer[..]);
         f.debug_struct("Base64Decoder")
             .field("config", &self.config)
-            .field("inner", &"BufReader".to_string())
+            .field("inner", &"BufReader")
             .field("out", &self.out)
             .field("out_buffer", &out_buf)
             .field("err", &self.err)

--- a/src/packet/many.rs
+++ b/src/packet/many.rs
@@ -251,20 +251,20 @@ mod tests {
             })
             .filter(|(offset, _, _)| {
                 // skip certain packages we are not (yet) parsing
-                offset != &"1193538".to_string() && // invalid mpi
-                offset != &"5053086".to_string() && // invalid mpi
-                offset != &"8240010".to_string() && // unknown public key algorithm 100
-                offset != &"9758352".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"9797527".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"11855679".to_string() &&  // TODO: unclear why this sig fails to parse
-                offset != &"11855798".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"11856933".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"11857023".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"11857113".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"12688657".to_string() && // TODO: unclear why this sig fails to parse
-                offset != &"24798372".to_string() && // TODO: unclear why this public sub key fails to parse
-                offset != &"24810682".to_string() && // bad attribute size
-                offset != &"38544535".to_string() // bad attribute size
+                offset != "1193538" && // invalid mpi
+                offset != "5053086" && // invalid mpi
+                offset != "8240010" && // unknown public key algorithm 100
+                offset != "9758352" && // TODO: unclear why this sig fails to parse
+                offset != "9797527" && // TODO: unclear why this sig fails to parse
+                offset != "11855679" && // TODO: unclear why this sig fails to parse
+                offset != "11855798" && // TODO: unclear why this sig fails to parse
+                offset != "11856933" && // TODO: unclear why this sig fails to parse
+                offset != "11857023" && // TODO: unclear why this sig fails to parse
+                offset != "11857113" && // TODO: unclear why this sig fails to parse
+                offset != "12688657" && // TODO: unclear why this sig fails to parse
+                offset != "24798372" && // TODO: unclear why this public sub key fails to parse
+                offset != "24810682" && // bad attribute size
+                offset != "38544535" // bad attribute size
             });
 
         let actual_tags = PacketParser::new(file).filter(|p| p.is_ok());

--- a/src/types/secret_key_repr.rs
+++ b/src/types/secret_key_repr.rs
@@ -32,7 +32,7 @@ pub struct ECDHSecretKey {
 impl fmt::Debug for ECDHSecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ECDHSecretKey")
-            .field("secret", &"[..]".to_string())
+            .field("secret", &"[..]")
             .field("hash", &self.hash)
             .field("oid", &hex::encode(&self.oid))
             .field("alg_sym", &self.alg_sym)
@@ -52,7 +52,7 @@ pub struct EdDSASecretKey {
 impl fmt::Debug for EdDSASecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EdDSASecretKey")
-            .field("secret", &"[..]".to_string())
+            .field("secret", &"[..]")
             .field("oid", &hex::encode(&self.oid))
             .finish()
     }
@@ -67,8 +67,6 @@ pub struct DSASecretKey {
 
 impl fmt::Debug for DSASecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DSASecretKey")
-            .field("x", &"[..]".to_string())
-            .finish()
+        f.debug_struct("DSASecretKey").field("x", &"[..]").finish()
     }
 }


### PR DESCRIPTION
&String can be compared with &str and &str satisfies the trait bounds
for std::fmt::builders::DebugStruct::field.