### PR TITLE
Fix zeroize version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ signature = "1.3.0"
 smallvec = "1.6.1"
 thiserror = "1.0.9"
 twofish = "^0.6"
-zeroize = { version = "~1.4.0", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.0", features = ["zeroize_derive"] }
 getrandom = { version = "0.2.3", optional = true }
 
 [dependencies.buf_redux]


### PR DESCRIPTION
Fixes #179 

This removes the non-standard requirement on zeroize, fixing ecosystem incompatibilities with rpgp.