### PR TITLE
Remove unused clear_on_drop dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ cfb-mode = "^0.7.0"
 chrono = { version = "^0.4", default-features = false, features = ["clock", "std"] }
 circular = "^0.3"
 cipher = "^0.3"
-clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 crc24 = "^0.1"
 derive_builder = "0.9.0"
 des = "^0.7"
@@ -96,7 +95,7 @@ serde_json = "^1.0"
 
 [features]
 default = []
-nightly = ["ed25519-dalek/nightly", "rsa/nightly", "rand/nightly", "num-bigint/nightly", "clear_on_drop/nightly"]
+nightly = ["ed25519-dalek/nightly", "rsa/nightly", "rand/nightly", "num-bigint/nightly"]
 profile = ["gperftools"]
 asm = ["sha-1/asm", "sha2/asm", "md-5/asm", "nightly"]
 wasm = ["chrono/wasmbind", "getrandom", "getrandom/js"]


### PR DESCRIPTION
`clear_on_drop` seems to be completely replaced by `#[zeroize(drop)]`.