### PR TITLE
Replace find_map with a find

### DIFF
--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -476,13 +476,10 @@ impl Message {
                             }
 
                             if encoding_key.is_none() {
-                                encoding_subkey = key.secret_subkeys.iter().find_map(|subkey| {
-                                    if &subkey.key_id() == esk_packet.id() {
-                                        Some(subkey)
-                                    } else {
-                                        None
-                                    }
-                                });
+                                encoding_subkey = key
+                                    .secret_subkeys
+                                    .iter()
+                                    .find(|&subkey| &subkey.key_id() == esk_packet.id());
                             }
 
                             if encoding_key.is_some() || encoding_subkey.is_some() {


### PR DESCRIPTION
The argument is not transformed, so find is sufficient.

This change fixes a clippy error causing the CI to fail.