### PR TITLE
feat: allow subkeys to be created with the authentication flag enabled

### DIFF
--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -68,6 +68,8 @@ pub struct SubkeyParams {
     can_create_certificates: bool,
     #[builder(default)]
     can_encrypt: bool,
+    #[builder(default)]
+    can_authenticate: bool,
 
     #[builder(default)]
     user_ids: Vec<UserId>,
@@ -185,6 +187,7 @@ impl SecretKeyParams {
                     keyflags.set_encrypt_comms(subkey.can_encrypt);
                     keyflags.set_encrypt_storage(subkey.can_encrypt);
                     keyflags.set_sign(subkey.can_sign);
+                    keyflags.set_authentication(subkey.can_authenticate);
 
                     Ok(SecretSubkey::new(
                         packet::SecretSubkey {


### PR DESCRIPTION
The method `can_authenticate(bool)` was missing from the `SubkeyParams` builder but was supported by everything further down.  I have tested this by generating a key that has an authenticate subkey and using this to successfully log into a Linux server using SSH.