### PR TITLE
Do not treat all signatures with mismatching key ID as valid

### DIFF
--- a/src/packet/signature/types.rs
+++ b/src/packet/signature/types.rs
@@ -88,8 +88,8 @@ impl Signature {
                     &key.key_id(),
                     issuer
                 );
-                // We can't validate this against this key, as there is a missmatch.
-                return Ok(());
+                // We can't validate this against this key, as there is a mismatch.
+                bail!("key ID mismatch");
             }
         }
 
@@ -125,8 +125,8 @@ impl Signature {
                     "validating certificate with a non matching Key ID {:?} != {:?}",
                     key_id, issuer
                 );
-                // We can't validate this against this key, as there is a missmatch.
-                return Ok(());
+                // We can't validate this against this key, as there is a mismatch.
+                bail!("key ID mismatch");
             }
         }
 
@@ -244,8 +244,8 @@ impl Signature {
                     "validating key (revocation) with a non matching Key ID {:?} != {:?}",
                     &key_id, issuer
                 );
-                // We can't validate this against this key, as there is a missmatch.
-                return Ok(());
+                // We can't validate this against this key, as there is a mismatch.
+                bail!("key ID mismatch");
             }
         }
 


### PR DESCRIPTION
This looks like a typo introduced in
https://github.com/rpgp/rpgp/pull/215

This leads to skip of validation for signatures with mismatching ID, but instead of returning an error, the signatures are treated as valid.

This PR was later squashed into commit
https://github.com/rpgp/rpgp/commit/a463cca1cb2bbefe4bb3148babee3685a06a14a6