### PR TITLE
Fix a couple of minor points in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > OpenPGP implemented in pure Rust, permissively licensed
 
-rPGP is the only full Rust implementation of OpenPGP, following [RFC4880](https://tools.ietf.org/html/rfc4880.html) and [RFC2440](https://tools.ietf.org/html/rfc2440). It offers a minimal low-level API and does not prescribe trust schemes or key management policies. It fully supports all functionality required by the [Autocrypt 1.1 e-mail encryption specification](https://autocrypt.org/level1.html).
+rPGP is the only pure Rust implementation of OpenPGP, following [RFC4880](https://tools.ietf.org/html/rfc4880.html) and [RFC2440](https://tools.ietf.org/html/rfc2440). It offers a minimal low-level API and does not prescribe trust schemes or key management policies. It fully supports all functionality required by the [Autocrypt 1.1 e-mail encryption specification](https://autocrypt.org/level1.html).
 
 rPGP is regularly published as [the `pgp` Crate](https://crates.io/crates/pgp/) and its [RSA](https://crates.io/crates/rsa) implementation
 lives under the collective [RustCrypto umbrella](https://github.com/RustCrypto/RSA).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ And then run tests with `RUST_LOG=pgp=info`.
 
 Some key differences:
 
-- rPGP has a more libre license than Sequoia, which allows a broader usage
+- rPGP has a more permissive license than Sequoia, which allows a broader usage
 
 - rPGP is a library with a well-defined, relatively small feature-set
   where Sequoia also tries to be a replacement for the GPG command line tool

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Some key differences:
   where Sequoia also tries to be a replacement for the GPG command line tool
 
 - All crypto used in rPGP is implemented in pure Rust,
-  whereas sequoia uses Nettle, which is implemented in C.
+  whereas Sequoia by default uses Nettle, which is implemented in C.
 
 
 ## Minimum Supported Rust Version (MSRV)


### PR DESCRIPTION
Hi!

This PR addresses three minor README points:

1. use `permissive` instead of `libre`

`Libre` is often associated with GNU and their [GPL licenses][0]. Avoid that wording and instead use `permissive` that immediately evokes [Apache and MIT licenses][1].

[0]: https://www.gnu.org/philosophy/free-sw.en.html

[1]: https://en.wikipedia.org/wiki/Permissive_software_license

2. Mention default Nettle for Sequoia

Sequoia can use [several different cryptographic backends besides Nettle][2] even though Nettle is configured as a default backend.

[2]: https://gitlab.com/sequoia-pgp/sequoia/-/blob/main/openpgp/README.md#crypto-backends

3. Use `pure Rust` instead of `full Rust`.

I think it's more idiomatic to say `pure Rust` while `full Rust` is not so straightforward.

(Full disclosure: I am paid by Sequoia to work on their codebase. I'm *not* paid to issue this kind of PRs but I think it's incontroversial enough that my income sources are not relevant here.)

Thanks for your time!  :wave: 