### PR TITLE
feat: Implement `LowerHex` and `UpperHex` for `KeyId`

### DIFF
--- a/src/types/key_id.rs
+++ b/src/types/key_id.rs
@@ -31,3 +31,17 @@ impl fmt::Debug for KeyId {
         write!(f, "KeyId({})", hex::encode(self.as_ref()))
     }
 }
+
+impl fmt::LowerHex for KeyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.as_ref()))
+    }
+}
+
+impl fmt::UpperHex for KeyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut encoded = hex::encode(self.as_ref());
+        encoded.make_ascii_uppercase();
+        write!(f, "{}", encoded)
+    }
+}

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -1119,3 +1119,10 @@ fn test_handle_incomplete_packets_end() {
     let key = SignedSecretKey::from_bytes(Cursor::new(raw)).expect("failed");
     key.verify().expect("invalid key");
 }
+
+#[test]
+fn test_keyid_formatters() {
+    let keyid = KeyId::from_slice(&[0x4C, 0x07, 0x3A, 0xE0, 0xC8, 0x44, 0x5C, 0x0C]).unwrap();
+    assert_eq!("4C073AE0C8445C0C", format!("{:X}", keyid));
+    assert_eq!("4c073ae0c8445c0c", format!("{:x}", keyid));
+}


### PR DESCRIPTION
This allows formatting KeyId objects with `{:X}` and `{:x}` formatting specifiers.