### PR TITLE
perf: avoid `concat` in sha1 checksum impl

### DIFF
--- a/src/crypto/checksum.rs
+++ b/src/crypto/checksum.rs
@@ -82,6 +82,14 @@ impl Hasher for SimpleChecksum {
 
 /// SHA1 checksum, first 20 octets.
 #[inline]
-pub fn calculate_sha1(data: &[u8]) -> Vec<u8> {
-    Sha1::digest(data)[..20].to_vec()
+pub fn calculate_sha1<I, T>(data: I) -> Vec<u8>
+where
+    T: AsRef<[u8]>,
+    I: IntoIterator<Item = T>,
+{
+    let mut digest = Sha1::new();
+    for chunk in data {
+        digest.update(chunk.as_ref());
+    }
+    digest.finalize()[..20].to_vec()
 }

--- a/src/crypto/sym.rs
+++ b/src/crypto/sym.rs
@@ -169,7 +169,7 @@ impl SymmetricKeyAlgorithm {
         let mdc_len = 22;
         let (data, mdc) = res.split_at(res.len() - mdc_len);
 
-        let sha1 = checksum::calculate_sha1(&[prefix, data, &mdc[0..2]].concat());
+        let sha1 = checksum::calculate_sha1([prefix, data, &mdc[0..2]]);
         if mdc[0] != 0xD3 || // Invalid MDC tag
            mdc[1] != 0x14 || // Invalid MDC length
            mdc[2..] != sha1[..]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod ser;
 pub mod types;
 
 // reexports for easier use
+#[allow(unused_imports)]
 pub use self::composed::key::*;
 pub use self::composed::*;
 pub use self::packet::Signature;

--- a/src/types/params/plain_secret.rs
+++ b/src/types/params/plain_secret.rs
@@ -115,7 +115,7 @@ impl<'a> PlainSecretParamsRef<'a> {
     pub fn checksum_sha1(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         self.to_writer_raw(&mut buf).expect("known write target");
-        checksum::calculate_sha1(&buf)
+        checksum::calculate_sha1([&buf])
     }
 
     pub fn as_repr(&self, public_params: &PublicParams) -> Result<SecretKeyRepr> {


### PR DESCRIPTION
When decrypting large files, the `data` used in the `sym::SymmetricKeyAlgorithm::decrypt_protected` method would be copied via the `concat` used when taking the checksum.

This change updates the function to avoid the copy, by iterating over the relevant parts of the checksum as immutable references. This should be "transparent" to the overall api of the lib so I thought it might make a nice change.

### Use Case

I am using `gpg` to create large filesystem updates (basically, `.ext4.gpg`) that can be several hundred MB in size, destined for embedded machines with only several hundred MB of RAM. On those machines, I am using this library in my application to decrypt the updates and apply them. Currently, I am running out of memory during the process.

I did some testing to verify that `concat` does indeed result in allocations here: [gist.github.com/dadleyy/a7f8f01](https://gist.github.com/dadleyy/a7f8f01d9e79dcc51641e72becc22467), using the `Instruments` application on my macOS machine. 