### PR TITLE
Handle other RevocationCode values

### DIFF
--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -242,10 +242,7 @@ fn features(body: &[u8]) -> IResult<&[u8], SubpacketData> {
 /// Ref: https://tools.ietf.org/html/rfc4880.html#section-5.2.3.23
 fn rev_reason(i: &[u8]) -> IResult<&[u8], SubpacketData> {
     map(
-        pair(
-            map_res(be_u8, RevocationCode::try_from),
-            map(rest, BString::from),
-        ),
+        pair(map(be_u8, RevocationCode::from), map(rest, BString::from)),
         |(code, reason)| SubpacketData::RevocationReason(code, reason),
     )(i)
 }

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -489,6 +489,8 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
+    use crate::{Deserializable, StandaloneSignature};
+    use std::io::Cursor;
 
     #[test]
     fn test_subpacket_pref_sym_alg() {
@@ -503,5 +505,25 @@ mod tests {
                     .collect()
             )
         );
+    }
+
+    #[test]
+    fn test_unknown_revocation_code() {
+        let revocation = "-----BEGIN PGP SIGNATURE-----
+
+wsASBCAWCgCEBYJlrwiYCRACvMqAWdPpHUcUAAAAAAAeACBzYWx0QG5vdGF0aW9u
+cy5zZXF1b2lhLXBncC5vcmfPfjVZJ9PXSt4854s05WU+Tj5QZwuhA5+LEHEUborP
+PxQdQnJldm9jYXRpb24gbWVzc2FnZRYhBKfuT6/w5BLl1XTGUgK8yoBZ0+kdAABi
+lQEAkpvZ3A2RGtRdCne/dOZtqoX7oCCZKCPyfZS9I9roc5oBAOj4aklEBejYuTKF
+SW+kj0jFDKC2xb/o8hbkTpwPtsoI
+=0ajX
+-----END PGP SIGNATURE-----";
+
+        let (sig, _) = StandaloneSignature::from_armor_single(Cursor::new(revocation)).unwrap();
+
+        let rc = sig.signature.revocation_reason_code();
+
+        assert!(rc.is_some());
+        assert!(matches!(rc.unwrap(), RevocationCode::Other(0x42)));
     }
 }

--- a/src/packet/signature/ser.rs
+++ b/src/packet/signature/ser.rs
@@ -53,7 +53,7 @@ impl Subpacket {
                 writer.write_all(features)?;
             }
             SubpacketData::RevocationReason(code, reason) => {
-                writer.write_all(&[*code as u8])?;
+                writer.write_all(&[u8::from(*code)])?;
                 writer.write_all(reason)?;
             }
             SubpacketData::IsPrimary(is_primary) => {

--- a/src/packet/signature/types.rs
+++ b/src/packet/signature/types.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use bstr::{BStr, BString};
 use byteorder::{BigEndian, ByteOrder};
 use chrono::{DateTime, Utc};
-use num_enum::TryFromPrimitive;
+use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 
 use crate::crypto::aead::AeadAlgorithm;
 use crate::crypto::hash::HashAlgorithm;
@@ -780,7 +780,7 @@ pub struct Notation {
 }
 
 /// Codes for revocation reasons
-#[derive(Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum RevocationCode {
     /// No reason specified (key revocations or cert revocations)
@@ -793,6 +793,23 @@ pub enum RevocationCode {
     KeyRetired = 3,
     /// User ID information is no longer valid (cert revocations)
     CertUserIdInvalid = 32,
+
+    /// Private Use range (from OpenGPG)
+    Private100 = 100,
+    Private101 = 101,
+    Private102 = 102,
+    Private103 = 103,
+    Private104 = 104,
+    Private105 = 105,
+    Private106 = 106,
+    Private107 = 107,
+    Private108 = 108,
+    Private109 = 109,
+    Private110 = 110,
+
+    /// Undefined code
+    #[num_enum(catch_all)]
+    Other(u8),
 }
 
 impl fmt::Debug for Signature {


### PR DESCRIPTION
Currently, when reading a revocation signature with an unknown "revocation code" value, the "revocation code" field is dropped during parsing, so it's missing from the resulting `Signature` struct. As a result, `Signature::verify_key()`  considers the cryptographic signature to be wrong.

So applications have to assume such a revocation is "fake", and ignore it, because the self-signature is broken. In such a case, applications will ignore a legitimately self-signed revocation, just because the "revocation code" field contains an unexpected value. This seems like an unfortunate failure mode.

This PR implements parsing (and serialization) for any u8 value in the code field.
If there is a better way to implement this, I'd be happy about pointers, and to improve this PR.