### PR TITLE
fix: return an error in Message::verify if we don't know what to verify

### DIFF
--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -413,9 +413,10 @@ impl Message {
                 let msg = Message::from_bytes(data.decompress()?)?;
                 msg.verify(key)
             }
-            // Nothing to do for others.
-            // TODO: should this return an error?
-            _ => Ok(()),
+            // We don't know how to verify a signature for other Message types, and shouldn't return Ok
+            _ => Err(Error::Unsupported(format!(
+                "Unexpected message format: {self:?}",
+            ))),
         }
     }
 


### PR DESCRIPTION
This change makes it harder for users of the API to mistakenly think they have successfully validated a message, when in fact they have used the API wrong.