### PR TITLE
ignore clippy false positive

### DIFF
--- a/src/armor/reader.rs
+++ b/src/armor/reader.rs
@@ -387,6 +387,8 @@ impl<R: Read + Seek> Dearmor<R> {
             self.base_decoder = Some(Base64Decoder::new(Base64Reader::new(LineReader::new(b))));
         }
 
+        // "allow" as workaround for https://github.com/rust-lang/rust-clippy/issues/12208
+        #[allow(clippy::unused_io_amount)]
         let size = if let Some(ref mut base_decoder) = self.base_decoder {
             base_decoder.read(into)?
         } else {


### PR DESCRIPTION
I initially added this `ignore` as a commit in #271.

But now think it might be good to push this to main right away (other PRs keep showing this false positive)