### PR TITLE
Fix CI status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ dual licensed as above, without any additional terms or conditions.
 [doc-link]: https://docs.rs/crate/pgp/
 [license-image]: https://img.shields.io/badge/License-MIT%2FApache2.0-green.svg?style=flat-square
 [license-link]: https://github.com/rpgp/rpgp/blob/master/LICENSE.md
-[build-image]: https://github.com/rpgp/rpgp/workflows/CI/badge.svg
+[build-image]: https://github.com/rpgp/rpgp/actions/workflows/ci.yml/badge.svg
 [build-link]: https://github.com/rpgp/rpgp/actions?query=workflow%3ACI+branch%3Amaster
 [msrv-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [deps-image]: https://deps.rs/repo/github/rpgp/rpgp/status.svg

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ dual licensed as above, without any additional terms or conditions.
 [license-link]: https://github.com/rpgp/rpgp/blob/master/LICENSE.md
 [build-image]: https://github.com/rpgp/rpgp/actions/workflows/ci.yml/badge.svg
 [build-link]: https://github.com/rpgp/rpgp/actions?query=workflow%3ACI+branch%3Amaster
-[msrv-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.70+-blue.svg
 [deps-image]: https://deps.rs/repo/github/rpgp/rpgp/status.svg
 [deps-link]: https://deps.rs/repo/github/rpgp/rpgp


### PR DESCRIPTION
I've noticed that the image shows "build failing" but the CI succeeds and works (as evidenced by clicking the link) so I went to Actions and pressed "Create status badge" and replaced the link below with what was suggested by GitHub.

Edit: I've noticed the Rust version badge was also out of date so I've fixed that too to reflect what is written as text.