### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/composed/shared.rs
+++ b/src/composed/shared.rs
@@ -19,7 +19,7 @@ pub trait Deserializable: Sized {
     }
 
     /// Parse an armor encoded list of compositions.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
+    #[allow(clippy::type_complexity)]
     fn from_string_many<'a>(
         input: &'a str,
     ) -> Result<(
@@ -36,7 +36,7 @@ pub trait Deserializable: Sized {
     }
 
     /// Armored ascii data.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
+    #[allow(clippy::type_complexity)]
     fn from_armor_many<'a, R: Read + Seek + 'a>(
         input: R,
     ) -> Result<(

--- a/src/composed/signed_key/parse.rs
+++ b/src/composed/signed_key/parse.rs
@@ -12,7 +12,7 @@ use crate::types::Tag;
 // TODO: can detect armored vs binary using a check if the first bit in the data is set. If it is cleared it is not a binary message, so can try to parse as armor ascii. (from gnupg source)
 
 /// Parses a list of secret and public keys from ascii armored text.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
+#[allow(clippy::type_complexity)]
 pub fn from_armor_many<'a, R: io::Read + io::Seek + 'a>(
     input: R,
 ) -> Result<(

--- a/src/crypto/sym.rs
+++ b/src/crypto/sym.rs
@@ -196,7 +196,7 @@ impl SymmetricKeyAlgorithm {
     /// (128 bits), the IV is 18 octets long, and octets 17 and 18 replicate
     /// octets 15 and 16.  Those extra two octets are an easy check for a
     /// correct key.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::complexity))]
+    #[allow(clippy::complexity)]
     pub fn decrypt_with_iv<'a>(
         self,
         key: &[u8],

--- a/src/packet/packet_sum.rs
+++ b/src/packet/packet_sum.rs
@@ -11,7 +11,7 @@ use crate::ser::Serialize;
 use crate::types::{Tag, Version};
 
 #[derive(Debug)]
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::large_enum_variant))] // TODO: fix me
+#[allow(clippy::large_enum_variant)] // TODO: fix me
 pub enum Packet {
     CompressedData(CompressedData),
     PublicKey(PublicKey),

--- a/src/packet/signature/types.rs
+++ b/src/packet/signature/types.rs
@@ -35,7 +35,7 @@ pub struct Signature {
 }
 
 impl Signature {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::complexity))]
+    #[allow(clippy::complexity)]
     pub fn new(
         packet_version: Version,
         version: SignatureVersion,

--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -1,5 +1,5 @@
 // comes from inside somewhere of nom
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::useless_let_if_seq))]
+#![allow(clippy::useless_let_if_seq)]
 
 use std::num::NonZeroUsize;
 


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html