### PR TITLE
fix(ecdsa): don't pad ecdsa secret MPIs

### DIFF
--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -624,7 +624,7 @@ mod tests {
     #[test]
     fn key_gen_ecdsa_p256() {
         let rng = &mut ChaCha8Rng::seed_from_u64(0);
-        for _ in 0..100 {
+        for _ in 0..=175 {
             gen_ecdsa(rng, ECCCurve::P256);
         }
     }

--- a/src/types/mpi.rs
+++ b/src/types/mpi.rs
@@ -90,26 +90,6 @@ impl Mpi {
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
-
-    /// Strip trailing zeroes.
-    pub fn strip_trailing_zeroes(&mut self) {
-        let mut end = self.0.len();
-        for byte in self.0.iter().rev() {
-            if *byte == 0 {
-                end -= 1;
-            } else {
-                break;
-            }
-        }
-        self.0.truncate(end);
-    }
-
-    pub fn pad_right(&mut self, new_len: usize) {
-        if new_len <= self.0.len() {
-            return;
-        }
-        self.0.resize(new_len, 0u8);
-    }
 }
 
 impl std::ops::Deref for Mpi {

--- a/src/types/params/plain_secret.rs
+++ b/src/types/params/plain_secret.rs
@@ -75,7 +75,7 @@ impl<'a> PlainSecretParamsRef<'a> {
                 (*x).to_writer(writer)?;
             }
             PlainSecretParamsRef::ECDSA(x) => {
-                (*x).strip_trailing_zeroes().to_writer(writer)?;
+                (*x).to_writer(writer)?;
             }
             PlainSecretParamsRef::ECDH(x) => {
                 (*x).to_writer(writer)?;
@@ -206,25 +206,13 @@ impl<'a> PlainSecretParamsRef<'a> {
 }
 
 impl PlainSecretParams {
-    pub fn from_slice(data: &[u8], alg: PublicKeyAlgorithm, params: &PublicParams) -> Result<Self> {
-        let (_, mut repr) = parse_secret_params(alg)(data)?;
-        repr.normalize(params);
+    pub fn from_slice(
+        data: &[u8],
+        alg: PublicKeyAlgorithm,
+        _params: &PublicParams,
+    ) -> Result<Self> {
+        let (_, repr) = parse_secret_params(alg)(data)?;
         Ok(repr)
-    }
-
-    /// Normalize internal storage.
-    #[allow(clippy::single_match)]
-    fn normalize(&mut self, params: &PublicParams) {
-        match (self, params) {
-            (PlainSecretParams::ECDSA(secret_mpi), PublicParams::ECDSA(pub_params)) => {
-                // ECDSA varies in its storage of padded vs unpadded.
-                // This normalizes it to store the padded version in memory.
-                if let Some(len) = pub_params.secret_key_length() {
-                    secret_mpi.pad_right(len);
-                }
-            }
-            _ => {}
-        }
     }
 
     pub fn string_to_key_id(&self) -> u8 {


### PR DESCRIPTION
I've broken out the MPI padding-related part of #304.

I believe this fixes cases where the secret key MPI starts with a zero byte, but very much invite scrutiny.

For testing, I increased the number of rounds in `key_gen_ecdsa_p256` to include the first test case where the generated secret key has a leading zero byte. Without the changes in this PR, that test fails.