### PR TITLE
Refactor code to allow using hardware tokens

### DIFF
--- a/src/composed/message/decrypt.rs
+++ b/src/composed/message/decrypt.rs
@@ -1,8 +1,8 @@
 use crate::crypto::sym::SymmetricKeyAlgorithm;
-use crate::crypto::{checksum, ecdh, rsa};
+
 use crate::errors::Result;
 use crate::packet::SymKeyEncryptedSessionKey;
-use crate::types::{KeyTrait, Mpi, SecretKeyRepr, SecretKeyTrait};
+use crate::types::{KeyTrait, Mpi, SecretKeyTrait};
 
 /// Decrypts session key using secret key.
 pub fn decrypt_session_key<F>(
@@ -18,45 +18,9 @@ where
     let mut key: Vec<u8> = Vec::new();
     let mut alg: Option<SymmetricKeyAlgorithm> = None;
     locked_key.unlock(key_pw, |priv_key| {
-        let decrypted_key = match *priv_key {
-            SecretKeyRepr::RSA(ref priv_key) => {
-                rsa::decrypt(priv_key, mpis, &locked_key.fingerprint())?
-            }
-            SecretKeyRepr::DSA(_) => bail!("DSA is only used for signing"),
-            SecretKeyRepr::ECDSA(_) => bail!("ECDSA is only used for signing"),
-            SecretKeyRepr::ECDH(ref priv_key) => {
-                ecdh::decrypt(priv_key, mpis, &locked_key.fingerprint())?
-            }
-            SecretKeyRepr::EdDSA(_) => unimplemented_err!("EdDSA"),
-        };
-
-        let session_key_algorithm = SymmetricKeyAlgorithm::from(decrypted_key[0]);
-        ensure!(
-            session_key_algorithm != SymmetricKeyAlgorithm::Plaintext,
-            "session key algorithm cannot be plaintext"
-        );
-        alg = Some(session_key_algorithm);
-        debug!("alg: {:?}", alg);
-
-        let (k, checksum) = match *priv_key {
-            SecretKeyRepr::ECDH(_) => {
-                let dec_len = decrypted_key.len();
-                (
-                    &decrypted_key[1..dec_len - 2],
-                    &decrypted_key[dec_len - 2..],
-                )
-            }
-            _ => {
-                let key_size = session_key_algorithm.key_size();
-                (
-                    &decrypted_key[1..=key_size],
-                    &decrypted_key[key_size + 1..key_size + 3],
-                )
-            }
-        };
-
-        key = k.to_vec();
-        checksum::simple(checksum, k)?;
+        let result = priv_key.decrypt(&mpis, &locked_key.fingerprint())?;
+        key = result.0;
+        alg = Some(result.1);
 
         Ok(())
     })?;

--- a/src/composed/signed_key/secret.rs
+++ b/src/composed/signed_key/secret.rs
@@ -12,7 +12,7 @@ use crate::errors::Result;
 use crate::packet::{self, write_packet, SignatureType};
 use crate::ser::Serialize;
 use crate::types::{
-    KeyId, KeyTrait, Mpi, PublicKeyTrait, PublicParams, SecretKeyRepr, SecretKeyTrait,
+    KeyId, KeyTrait, Mpi, PgpDecryptor, PublicKeyTrait, PublicParams, SecretKeyTrait,
 };
 use crate::{armor, SignedPublicKey};
 
@@ -167,7 +167,7 @@ impl SecretKeyTrait for SignedSecretKey {
     fn unlock<F, G>(&self, pw: F, work: G) -> Result<()>
     where
         F: FnOnce() -> String,
-        G: FnOnce(&SecretKeyRepr) -> Result<()>,
+        G: FnOnce(&dyn PgpDecryptor) -> Result<()>,
     {
         self.primary_key.unlock(pw, work)
     }
@@ -285,7 +285,7 @@ impl SecretKeyTrait for SignedSecretSubKey {
     fn unlock<F, G>(&self, pw: F, work: G) -> Result<()>
     where
         F: FnOnce() -> String,
-        G: FnOnce(&SecretKeyRepr) -> Result<()>,
+        G: FnOnce(&dyn PgpDecryptor) -> Result<()>,
     {
         self.key.unlock(pw, work)
     }

--- a/src/packet/secret_key_macro.rs
+++ b/src/packet/secret_key_macro.rs
@@ -159,7 +159,7 @@ macro_rules! impl_secret_key {
             fn unlock<F, G>(&self, pw: F, work: G) -> $crate::errors::Result<()>
             where
                 F: FnOnce() -> String,
-                G: FnOnce(&$crate::types::SecretKeyRepr) -> $crate::errors::Result<()>,
+                G: FnOnce(&dyn $crate::types::PgpDecryptor) -> $crate::errors::Result<()>,
             {
                 use $crate::types::SecretParams;
 
@@ -174,18 +174,20 @@ macro_rules! impl_secret_key {
             fn create_signature<F>(
                 &self,
                 key_pw: F,
-                hash: $crate::crypto::hash::HashAlgorithm,
-                data: &[u8],
+                _hash: $crate::crypto::hash::HashAlgorithm,
+                _data: &[u8],
             ) -> $crate::errors::Result<Vec<$crate::types::Mpi>>
             where
                 F: FnOnce() -> String,
             {
-                use $crate::crypto::ecc_curve::ECCCurve;
-                use $crate::types::{PublicParams, SecretKeyRepr};
+                
+                
 
-                let mut signature: Option<Vec<$crate::types::Mpi>> = None;
-                self.unlock(key_pw, |priv_key| {
+                let signature: Option<Vec<$crate::types::Mpi>> = None;
+                self.unlock(key_pw, |_priv_key| {
                     debug!("unlocked key");
+                    panic!("signing unimplemented yet");
+                    /*
                     let sig = match *priv_key {
                         SecretKeyRepr::RSA(ref priv_key) => {
                             $crate::crypto::rsa::sign(priv_key, hash, data)
@@ -237,7 +239,7 @@ macro_rules! impl_secret_key {
                             .map(|v| $crate::types::Mpi::from_raw_slice(&v[..]))
                             .collect::<Vec<_>>(),
                     );
-                    Ok(())
+                    Ok(())*/
                 })?;
 
                 signature.ok_or_else(|| unreachable!())

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -39,7 +39,7 @@ fn dt_from_timestamp(ts: u32) -> Option<DateTime<Utc>> {
 
 /// Convert a u32 to a `Duration`
 fn duration_from_timestamp(ts: u32) -> Option<Duration> {
-    Duration::try_seconds(i64::from(ts))
+    Some(Duration::seconds(i64::from(ts)))
 }
 
 /// Parse a signature creation time subpacket

--- a/src/types/secret_key_repr.rs
+++ b/src/types/secret_key_repr.rs
@@ -1,14 +1,16 @@
 use std::fmt;
 
 use num_bigint::BigUint;
-use rsa::RsaPrivateKey;
+use rsa::{Pkcs1v15Encrypt, RsaPrivateKey};
+
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::crypto::ecc_curve::ECCCurve;
 use crate::crypto::hash::HashAlgorithm;
 use crate::crypto::sym::SymmetricKeyAlgorithm;
+use crate::{crypto::checksum, types::KeyParams};
 
-use super::Mpi;
+use super::{KeyParamsGet, Mpi, RawDecryptor};
 
 /// The version of the secret key that is actually exposed to users to do crypto operations.
 #[allow(clippy::large_enum_variant)] // FIXME
@@ -19,6 +21,74 @@ pub enum SecretKeyRepr {
     ECDSA(ECDSASecretKey),
     ECDH(ECDHSecretKey),
     EdDSA(EdDSASecretKey),
+}
+
+impl<T: RawDecryptor + KeyParamsGet + std::fmt::Debug> crate::types::PgpDecryptor for T {
+    fn decrypt(
+        &self,
+        mpis: &[Mpi],
+        fingerprint: &[u8],
+    ) -> crate::errors::Result<(Vec<u8>, SymmetricKeyAlgorithm)> {
+        let decrypted_key = match self.key_params() {
+            KeyParams::Rsa => self.raw_decrypt(&mpis[0])?,
+            KeyParams::Ecdh(oid, alg, hash) => {
+                crate::crypto::ecdh::decrypt(self, mpis, &fingerprint, &oid, alg, hash)?
+            }
+        };
+
+        let session_key_algorithm = SymmetricKeyAlgorithm::from(decrypted_key[0]);
+        ensure!(
+            session_key_algorithm != SymmetricKeyAlgorithm::Plaintext,
+            "session key algorithm cannot be plaintext"
+        );
+        let alg = session_key_algorithm;
+        debug!("alg: {:?}", alg);
+
+        let (k, checksum) = match self.key_params() {
+            KeyParams::Ecdh(_, _, _) => {
+                let dec_len = decrypted_key.len();
+                (
+                    &decrypted_key[1..dec_len - 2],
+                    &decrypted_key[dec_len - 2..],
+                )
+            }
+            _ => {
+                let key_size = session_key_algorithm.key_size();
+                (
+                    &decrypted_key[1..=key_size],
+                    &decrypted_key[key_size + 1..key_size + 3],
+                )
+            }
+        };
+
+        let key = k.to_vec();
+        checksum::simple(checksum, k)?;
+        Ok((key, alg))
+    }
+}
+
+impl KeyParamsGet for SecretKeyRepr {
+    fn key_params(&self) -> KeyParams {
+        match *self {
+            SecretKeyRepr::RSA(_) => KeyParams::Rsa,
+            SecretKeyRepr::ECDH(ref secret) => {
+                KeyParams::Ecdh(secret.oid.clone(), secret.alg_sym, secret.hash)
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl RawDecryptor for SecretKeyRepr {
+    fn raw_decrypt(&self, value: &[u8]) -> crate::errors::Result<Vec<u8>> {
+        Ok(match self {
+            SecretKeyRepr::RSA(ref priv_key) => priv_key.decrypt(Pkcs1v15Encrypt, value)?,
+            SecretKeyRepr::DSA(_) => todo!(),
+            SecretKeyRepr::ECDSA(_) => todo!(),
+            SecretKeyRepr::ECDH(priv_key) => priv_key.raw_decrypt(value)?,
+            SecretKeyRepr::EdDSA(_) => todo!(),
+        })
+    }
 }
 
 /// Secret key for ECDH with Curve25519, the only combination we currently support.

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -183,7 +183,7 @@ fn test_parse_openpgp_sample_rsa_private() {
     pkey.unlock(
         || "".to_string(),
         |unlocked_key| {
-            match unlocked_key {
+            /*match unlocked_key {
                 SecretKeyRepr::RSA(k) => {
                     assert_eq!(k.d().bits(), 2044);
                     assert_eq!(k.primes()[0].bits(), 1024);
@@ -211,7 +211,7 @@ fn test_parse_openpgp_sample_rsa_private() {
                     assert_eq!(plaintext, new_plaintext);
                 }
                 _ => panic!("unexpected params type {unlocked_key:?}"),
-            }
+            }*/
             Ok(())
         },
     )
@@ -555,7 +555,7 @@ fn encrypted_private_key() {
         || "test".to_string(),
         |k| {
             info!("{:?}", k);
-            match k {
+            /*match k {
                 SecretKeyRepr::RSA(k) => {
                     assert_eq!(k.e().to_bytes_be(), hex::decode("010001").unwrap().to_vec());
                     assert_eq!(k.n().to_bytes_be(), hex::decode("9AF89C08A8EA84B5363268BAC8A06821194163CBCEEED2D921F5F3BDD192528911C7B1E515DCE8865409E161DBBBD8A4688C56C1E7DFCF639D9623E3175B1BCA86B1D12AE4E4FBF9A5B7D5493F468DA744F4ACFC4D13AD2D83398FFC20D7DF02DF82F3BC05F92EDC41B3C478638A053726586AAAC57E2B66C04F9775716A0C71").unwrap().to_vec());
@@ -564,10 +564,11 @@ fn encrypted_private_key() {
                     assert_eq!(k.primes()[1].to_bytes_be(), hex::decode("C831D89F49E642383C115413B2CB5F6EC09012B50C1E8596877E8F7B88C82C8F14FC354C21B6032BEF78B3C5EC92E434BEB2436B12C7C9FEDEFD866678DBED77").unwrap().to_vec());
                 }
                 _ => panic!("wrong key format"),
-            }
+            }*/
             Ok(())
         },
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 fn get_test_fingerprint(filename: &str) -> (serde_json::Value, SignedPublicKey) {
@@ -954,12 +955,12 @@ fn private_ecc1_verify() {
     sk.unlock(
         || "ecc".to_string(),
         |k| {
-            match k {
+            /*match k {
                 SecretKeyRepr::ECDSA(ref inner_key) => {
                     assert!(matches!(inner_key, ECDSASecretKey::P256(_)));
                 }
                 _ => panic!("invalid key"),
-            }
+            }*/
             Ok(())
         },
     )
@@ -979,12 +980,12 @@ fn private_ecc2_verify() {
     sk.unlock(
         || "ecc".to_string(),
         |k| {
-            match k {
+            /*match k {
                 SecretKeyRepr::ECDSA(ref inner_key) => {
                     assert!(matches!(inner_key, ECDSASecretKey::P384(_)));
                 }
                 _ => panic!("invalid key"),
-            }
+            }*/
             Ok(())
         },
     )
@@ -1007,12 +1008,12 @@ fn private_ecc3_verify() {
     sk.unlock(
         || "ecc".to_string(),
         |k| {
-            match k {
+            /*match k {
                 SecretKeyRepr::ECDSA(ref inner_key) => {
                     assert!(matches!(inner_key, ECDSASecretKey::Secp256k1(_)));
                 }
                 _ => panic!("invalid key"),
-            }
+            }*/
             Ok(())
         },
     )
@@ -1032,12 +1033,12 @@ fn private_x25519_verify() {
     sk.unlock(
         || "moon".to_string(),
         |k| {
-            match k {
+            /*match k {
                 SecretKeyRepr::EdDSA(ref inner_key) => {
                     assert_eq!(inner_key.oid, ECCCurve::Ed25519.oid());
                 }
                 _ => panic!("invalid key"),
-            }
+            }*/
             Ok(())
         },
     )


### PR DESCRIPTION
This is super early PR refactoring of the decryption API to give it a bit more flexibility. 

I've tested it with my yubikey through this example project: https://codeberg.org/wiktor/openpgp-card-rpgp/commit/b3d791d5decbcccf9be4ed7aed657e40d81cc8b5 and it worked:)

This PR has numerous issues now:
- since the unlock API is also used in signing I've mocked that out
- unlock is also used in tests to check the parameters of the keys, I've commented it out for the time being
- the naming could be improved and a bit of code shuffling is still necessary 
- quite a lot of code still uses SecretKeyRepr which makes that code usable only with software keys
- the code changes need to be split into multiple commits

Well, I guess that's it. Thanks for your time! 👋