### PR TITLE
Freshen the repo's stale scent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For ECC crypto support we are using [Curve25519-dalek](https://crates.io/crates/
 > the tests which exercise the API. Please open issues here if if you are
 > attempting to use rPGP and need help.
 
-## Status (Last updated: October 2019)
+## Status (Last updated: February 2024)
 
 rPGP and its RSA dependency got an independent security audit mid 2019,
 see here for the [full report from IncludeSecurity](https://delta.chat/assets/blog/2019-first-security-review.pdf).


### PR DESCRIPTION
This PR is purely to freshen the scent conveyed by the readme. If merged, this PR removes the false stale scent therein.

**Previously**: the readme displays "Last updated: October 2019" in Heading 2 font, above the fold as the visitor starts reading.

This conveyed that this repo might be abandonware, which is the impression I conjured on my first TWO visits to the repo home page.

Then after repeatedly seeing links to this repo on socials I thought, why are all these people linking to abandonware?  It's only on my THIRD time that I realized, it's just the H2 that's sending the stale signal.

This PR updates the last time this particular section was updated, February 8 2024.

A pertinent question may be: why display a date in the H2 heading at all?

This PR freshens the date so at least the incorrect stale scent is removed.