### PR TITLE
add pgp::packet::sym_encrypted_protected_data::Data to the public API

### DIFF
--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -149,7 +149,7 @@ impl Edata {
     pub fn data(&self) -> &[u8] {
         match self {
             Edata::SymEncryptedData(d) => d.data(),
-            Edata::SymEncryptedProtectedData(d) => d.data(),
+            Edata::SymEncryptedProtectedData(d) => d.data_as_slice(),
         }
     }
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -123,3 +123,5 @@ pub use self::user_id::*;
 
 pub use self::many::*;
 pub use self::packet_sum::*;
+
+pub use self::sym_encrypted_protected_data::Data;

--- a/src/packet/sym_encrypted_protected_data.rs
+++ b/src/packet/sym_encrypted_protected_data.rs
@@ -22,7 +22,7 @@ pub struct SymEncryptedProtectedData {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-enum Data {
+pub enum Data {
     V1 {
         data: Vec<u8>,
     },
@@ -95,7 +95,11 @@ impl SymEncryptedProtectedData {
         Self::encrypt_with_rng(&mut thread_rng(), alg, key, plaintext)
     }
 
-    pub fn data(&self) -> &[u8] {
+    pub fn data(&self) -> &Data {
+        &self.data
+    }
+
+    pub fn data_as_slice(&self) -> &[u8] {
         match &self.data {
             Data::V1 { data } => data,
             Data::V2 { data, .. } => data,
@@ -109,7 +113,7 @@ impl SymEncryptedProtectedData {
         }
     }
 
-    /// Decryptes the inner data, returning the result.
+    /// Decrypts the inner data, returning the result.
     pub fn decrypt(
         &self,
         session_key: &[u8],


### PR DESCRIPTION
I don't think making `SymEncryptedProtectedData::data` pub is right, but `::data()` is already taken (and it doesn't return that field).

We probably want to shuffle this namespace around, some. Do you have an idea/preference?
Maybe `SymEncryptedProtectedData::data()` should be renamed to `::data_as_slice()` or something like that?