### PR TITLE
fix: decrypted data must contain exactly one message

### DIFF
--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -234,6 +234,12 @@ impl Edata {
             },
             PlainSessionKey::V6 { key } => match self {
                 Self::SymEncryptedProtectedData(p) => {
+                    ensure_eq!(
+                        self.version(),
+                        Some(2),
+                        "Version mismatch between key and integrity packet"
+                    );
+
                     let decrypted_packets = p.decrypt(&key, None)?;
                     Self::process_decrypted(&decrypted_packets[..])
                 }


### PR DESCRIPTION
I think performing these checks for all versions of encrypted messages is the right thing to do.