### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ version = "1.0.0"
 default-features = false
 
 [dependencies.curve25519-dalek]
-version = "4.1.2"
+version = "4.1.3"
 default-features = false
 features = ["alloc", "precomputed-tables", "zeroize"]
 


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)