### PR TITLE
Re-export bstr for user to use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,5 +54,7 @@ pub use self::composed::key::*;
 pub use self::composed::*;
 pub use self::packet::Signature;
 
+pub use bstr;
+
 /// The version of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
bstr is used in public API therefore it must be re-exported to alloow user to use it without need to manually check which version you use