### PR TITLE
revert to producing short padding for ecdh.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ pretty_env_logger = "0.5"
 rand_chacha = "0.3"
 rand_xorshift = "0.3"
 regex = "^1.7"
+rpgp_0_10 = { version = "=0.10.2", package = "pgp" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -390,20 +390,9 @@ pub fn kdf(hash: HashAlgorithm, x: &[u8], length: usize, param: &[u8]) -> Result
 fn pad(plain: &[u8]) -> Vec<u8> {
     let len = plain.len();
 
-    /// Our default target padded length (based on the size of a padded AES256 key).
-    /// This value should be increased if we support symmetric keys that are longer than AES256.
-    const PAD_DEFAULT_TARGET: usize = 40;
-
-    // The padded message length (must be a multiple of the block size)
-    let padded_len = if len < PAD_DEFAULT_TARGET {
-        // Normally, we just pad to the default target size ...
-        PAD_DEFAULT_TARGET
-    } else {
-        // ... but if `plain` isn't shorter than our target size, we pad to the next full block
-        let remainder = len % 8; // e.g. 3 for len==19
-
-        len + 8 - remainder // (e.g. "8 + 8 - 0 => 16", or "19 + 8 - 3 => 24")
-    };
+    // We produce "short padding" (between 1 and 8 bytes)
+    let remainder = len % 8; // (e.g. 3 for len==19)
+    let padded_len = len + 8 - remainder; // (e.g. "8 + 8 - 0 => 16", or "19 + 8 - 3 => 24")
     debug_assert!(padded_len % 8 == 0, "Unexpected padded_len {}", padded_len);
 
     // The value we'll use for padding (must not be zero, and fit into a u8)

--- a/tests/backward-compat.rs
+++ b/tests/backward-compat.rs
@@ -1,0 +1,120 @@
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+
+// Tests that check for backward compatibility with older versions of rpgp
+
+#[test]
+fn ecdh_roundtrip_with_rpgp_0_10() {
+    // Encrypt/decrypt roundtrip to validate that there is no padding breakage between rPGP versions.
+
+    // Context: rPGP versions before 0.11 couldn't handle "long padding" (that exceeds one block),
+    // see https://github.com/rpgp/rpgp/pull/280
+
+    // However, rPGP 0.12 - 0.13.1 emit "long padding" by default (see https://github.com/rpgp/rpgp/pull/307),
+    // which older rPGP cannot unpad (and thus not decrypt).
+
+    // To avoid incompatibility with the (erroneous) ecdh handling in rPGP <0.11, rPGP produces
+    // "short padding" again, starting with 0.13.2
+
+    // Note: We use AES128 in this test so that the encrypting party is able to use "long padding".
+
+    const MSG: &[u8] = b"hello world";
+
+    // a test-key with an ECDH(Curve25519) encryption subkey
+    const KEYFILE: &str = "./tests/unit-tests/padding/alice.key";
+
+    // 0.10 -> 0.10
+    let enc = encrypt_rpgp_0_10(MSG, KEYFILE);
+    let dec = decrypt_rpgp_0_10(&enc, KEYFILE);
+    assert_eq!(dec, MSG, "0.10 -> 0.10");
+
+    // 0.10 -> cur
+    let enc = encrypt_rpgp_0_10(MSG, KEYFILE);
+    let dec = decrypt_rpgp_cur(&enc, KEYFILE);
+    assert_eq!(dec, MSG, "0.10 -> cur");
+
+    // cur -> 0.10
+    let enc = encrypt_rpgp_cur(MSG, KEYFILE);
+    let dec = decrypt_rpgp_0_10(&enc, KEYFILE);
+    assert_eq!(dec, MSG, "cur -> 0.10");
+
+    // cur -> cur
+    let enc = encrypt_rpgp_cur(MSG, KEYFILE);
+    let dec = decrypt_rpgp_cur(&enc, KEYFILE);
+    assert_eq!(dec, MSG, "cur -> cur");
+}
+
+fn decrypt_rpgp_0_10(enc_msg: &str, keyfile: &str) -> Vec<u8> {
+    use rpgp_0_10::Deserializable;
+
+    let (enc_msg, _) = rpgp_0_10::Message::from_string(enc_msg).unwrap();
+
+    let (ssk, _headers) =
+        rpgp_0_10::SignedSecretKey::from_armor_single(std::fs::File::open(keyfile).unwrap())
+            .expect("failed to read key");
+
+    let (mut dec, _) = enc_msg
+        .decrypt(|| "".to_string(), &[&ssk])
+        .expect("decrypt_rpgp_0_10");
+    let inner = dec.next().unwrap().unwrap();
+
+    inner.get_literal().unwrap().data().to_vec()
+}
+
+fn decrypt_rpgp_cur(enc_msg: &str, keyfile: &str) -> Vec<u8> {
+    use pgp::Deserializable;
+
+    let (enc_msg, _) = pgp::Message::from_string(enc_msg).expect("decrypt_rpgp_cur");
+
+    let (ssk, _headers) =
+        pgp::SignedSecretKey::from_armor_single(std::fs::File::open(keyfile).unwrap())
+            .expect("failed to read key");
+
+    let (dec, _) = enc_msg.decrypt(|| "".to_string(), &[&ssk]).unwrap();
+
+    dec.get_literal().unwrap().data().to_vec()
+}
+
+fn encrypt_rpgp_0_10(msg: &[u8], keyfile: &str) -> String {
+    use rpgp_0_10::crypto::sym::SymmetricKeyAlgorithm;
+    use rpgp_0_10::Deserializable;
+
+    let mut rng = ChaChaRng::from_seed([0u8; 32]);
+
+    let lit = rpgp_0_10::packet::LiteralData::from_bytes((&[]).into(), msg);
+    let msg = rpgp_0_10::Message::Literal(lit);
+
+    let (ssk, _headers) =
+        rpgp_0_10::SignedSecretKey::from_armor_single(std::fs::File::open(keyfile).unwrap())
+            .expect("failed to read key");
+
+    let enc = &ssk.secret_subkeys[0];
+
+    let enc_msg = msg
+        .encrypt_to_keys(&mut rng, SymmetricKeyAlgorithm::AES128, &[enc])
+        .unwrap();
+
+    enc_msg.to_armored_string(None).unwrap()
+}
+
+fn encrypt_rpgp_cur(msg: &[u8], keyfile: &str) -> String {
+    use pgp::crypto::sym::SymmetricKeyAlgorithm;
+    use pgp::{ArmorOptions, Deserializable};
+
+    let mut rng = ChaChaRng::from_seed([0u8; 32]);
+
+    let lit = pgp::packet::LiteralData::from_bytes((&[]).into(), msg);
+    let msg = pgp::Message::Literal(lit);
+
+    let (ssk, _headers) =
+        pgp::SignedSecretKey::from_armor_single(std::fs::File::open(keyfile).unwrap())
+            .expect("failed to read key");
+
+    let enc = &ssk.secret_subkeys[0];
+
+    let enc_msg = msg
+        .encrypt_to_keys(&mut rng, SymmetricKeyAlgorithm::AES128, &[enc])
+        .unwrap();
+
+    enc_msg.to_armored_string(ArmorOptions::default()).unwrap()
+}


### PR DESCRIPTION
this style of padding is compatible with older rpgp versions (long padding can only be read in v0.11.0 and newer, via #280).

this commit effectively undoes #307.