### PR TITLE
feat: Make `SignatureConfig::hash_signature_data` more flexible

### DIFF
--- a/src/packet/signature/types.rs
+++ b/src/packet/signature/types.rs
@@ -220,7 +220,7 @@ impl Signature {
         } else {
             self.config.hash_data_to_sign(&mut *hasher, data)?;
         }
-        let len = self.config.hash_signature_data(&mut *hasher)?;
+        let len = self.config.hash_signature_data(&mut hasher)?;
         hasher.update(&self.config.trailer(len)?);
 
         let hash = &hasher.finish()[..];
@@ -307,7 +307,7 @@ impl Signature {
             hasher.update(&packet_buf);
         }
 
-        let len = self.config.hash_signature_data(&mut *hasher)?;
+        let len = self.config.hash_signature_data(&mut hasher)?;
         hasher.update(&self.config.trailer(len)?);
 
         let hash = &hasher.finish()[..];
@@ -390,7 +390,7 @@ impl Signature {
             hasher.update(&key_buf);
         }
 
-        let len = self.config.hash_signature_data(&mut *hasher)?;
+        let len = self.config.hash_signature_data(&mut hasher)?;
         hasher.update(&self.config.trailer(len)?);
 
         let hash = &hasher.finish()[..];
@@ -426,7 +426,7 @@ impl Signature {
             hasher.update(&key_buf);
         }
 
-        let len = self.config.hash_signature_data(&mut *hasher)?;
+        let len = self.config.hash_signature_data(&mut hasher)?;
         hasher.update(&self.config.trailer(len)?);
 
         let hash = &hasher.finish()[..];


### PR DESCRIPTION
Hashers from RustCrypto implement `std::io::Write` and making use of that trait in the `hash_signature_data` makes it possible to use other hashers which do not implement RustCrypto Hasher trait.

Additionally it allows using hashers which may fail during the digest update (such as OpenSSL hashers).

(just for the context I'm using this in my [hasher-test](https://github.com/wiktor-k/hasher-test?tab=readme-ov-file#hasher-test) repository and the hasher I'm passing happens to be from a new `-pre` version of Rust Crypto's sha2 crate. Due to versioning for Rust it's not the same Hasher trait but the same Write trait).