### PR TITLE
Ignore another sks-dump test failure

### DIFF
--- a/src/packet/many.rs
+++ b/src/packet/many.rs
@@ -340,6 +340,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_many_parser() {
         let _ = pretty_env_logger::try_init();
 


### PR DESCRIPTION
If the submodule hasn't been cloned, then test_many_parsers will also fail, so ignore this failing test like the other ones that depend on the sks dump.