### PR TITLE
fix: Remove the MPI constructor which may be misused

### DIFF
--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -333,11 +333,11 @@ where
     Ok((
         PublicParams::ECDH {
             curve: curve.clone(),
-            p: Mpi::from_raw_slice(public.to_sec1_bytes().as_ref()),
+            p: Mpi::from_slice(public.to_sec1_bytes().as_ref()),
             hash: curve.hash_algo()?,
             alg_sym: curve.sym_algo()?,
         },
-        PlainSecretParams::ECDH(Mpi::from_raw_slice(secret.to_bytes().as_slice())),
+        PlainSecretParams::ECDH(Mpi::from_slice(secret.to_bytes().as_slice())),
     ))
 }
 
@@ -483,7 +483,7 @@ pub fn encrypt<R: CryptoRng + Rng>(
     let encrypted_session_key = aes_kw::wrap(&z, &plain_padded)?;
 
     Ok(PkeskBytes::Ecdh {
-        public_point: Mpi::from_raw_slice(&encoded_public),
+        public_point: Mpi::from_slice(&encoded_public),
         encrypted_session_key,
     })
 }

--- a/src/crypto/ecdsa.rs
+++ b/src/crypto/ecdsa.rs
@@ -111,12 +111,12 @@ pub fn generate_key<R: Rng + CryptoRng>(
         ECCCurve::P256 => {
             let secret = p256::SecretKey::random(&mut rng);
             let public = secret.public_key();
-            let secret = Mpi::from_raw_slice(secret.to_bytes().as_slice());
+            let secret = Mpi::from_slice(secret.to_bytes().as_slice());
 
             Ok((
                 PublicParams::ECDSA(EcdsaPublicParams::P256 {
                     key: public,
-                    p: Mpi::from_raw_slice(public.to_encoded_point(false).as_bytes()),
+                    p: Mpi::from_slice(public.to_encoded_point(false).as_bytes()),
                 }),
                 PlainSecretParams::ECDSA(secret),
             ))
@@ -125,12 +125,12 @@ pub fn generate_key<R: Rng + CryptoRng>(
         ECCCurve::P384 => {
             let secret = p384::SecretKey::random(&mut rng);
             let public = secret.public_key();
-            let secret = Mpi::from_raw_slice(secret.to_bytes().as_slice());
+            let secret = Mpi::from_slice(secret.to_bytes().as_slice());
 
             Ok((
                 PublicParams::ECDSA(EcdsaPublicParams::P384 {
                     key: public,
-                    p: Mpi::from_raw_slice(public.to_encoded_point(false).as_bytes()),
+                    p: Mpi::from_slice(public.to_encoded_point(false).as_bytes()),
                 }),
                 PlainSecretParams::ECDSA(secret),
             ))
@@ -139,12 +139,12 @@ pub fn generate_key<R: Rng + CryptoRng>(
         ECCCurve::P521 => {
             let secret = p521::SecretKey::random(&mut rng);
             let public = secret.public_key();
-            let secret = Mpi::from_raw_slice(secret.to_bytes().as_slice());
+            let secret = Mpi::from_slice(secret.to_bytes().as_slice());
 
             Ok((
                 PublicParams::ECDSA(EcdsaPublicParams::P521 {
                     key: public,
-                    p: Mpi::from_raw_slice(public.to_encoded_point(false).as_bytes()),
+                    p: Mpi::from_slice(public.to_encoded_point(false).as_bytes()),
                 }),
                 PlainSecretParams::ECDSA(secret),
             ))
@@ -153,12 +153,12 @@ pub fn generate_key<R: Rng + CryptoRng>(
         ECCCurve::Secp256k1 => {
             let secret = k256::SecretKey::random(&mut rng);
             let public = secret.public_key();
-            let secret = Mpi::from_raw_slice(secret.to_bytes().as_slice());
+            let secret = Mpi::from_slice(secret.to_bytes().as_slice());
 
             Ok((
                 PublicParams::ECDSA(EcdsaPublicParams::Secp256k1 {
                     key: public,
-                    p: Mpi::from_raw_slice(public.to_encoded_point(false).as_bytes()),
+                    p: Mpi::from_slice(public.to_encoded_point(false).as_bytes()),
                 }),
                 PlainSecretParams::ECDSA(secret),
             ))

--- a/src/crypto/eddsa.rs
+++ b/src/crypto/eddsa.rs
@@ -103,7 +103,7 @@ pub fn generate_key<R: Rng + CryptoRng>(
             q.extend_from_slice(&public.to_bytes());
 
             // secret key
-            let p = Mpi::from_raw_slice(&secret.to_bytes());
+            let p = Mpi::from_slice(&secret.to_bytes());
 
             (
                 PublicParams::EdDSALegacy {

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -103,7 +103,7 @@ pub fn encrypt<R: CryptoRng + Rng>(
     let data = key.encrypt(&mut rng, Pkcs1v15Encrypt, plaintext)?;
 
     Ok(PkeskBytes::Rsa {
-        mpi: Mpi::from_raw_slice(&data[..]),
+        mpi: Mpi::from_slice(&data[..]),
     })
 }
 

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -302,7 +302,7 @@ impl<D: PublicKeyTrait + PacketTrait + Clone + crate::ser::Serialize> SecretKeyT
                     // strip leading zeros, to match parse results from MPIs
                     let mpis = sig
                         .iter()
-                        .map(|v| Mpi::from_raw_slice(&v[..]))
+                        .map(|v| Mpi::from_slice(&v[..]))
                         .collect::<Vec<_>>();
 
                     signature = Some(SignatureBytes::Mpis(mpis));

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,7 +77,7 @@ pub fn strip_leading_zeros(bytes: &[u8]) -> &[u8] {
     bytes
         .iter()
         .position(|b| b != &0)
-        .map_or(bytes, |offset| &bytes[offset..])
+        .map_or(&[], |offset| &bytes[offset..])
 }
 
 #[inline]
@@ -238,5 +238,12 @@ mod tests {
         let mut res = Vec::new();
         write_packet_length(12870, &mut res).unwrap();
         assert_eq!(hex::encode(res), "ff00003246");
+    }
+
+    #[test]
+    fn test_strip_leading_zeros_with_all_zeros() {
+        let buf = [0, 0, 0];
+        let stripped = strip_leading_zeros(&buf);
+        assert_eq!(stripped, &[]);
     }
 }

--- a/tests/hsm-test.rs
+++ b/tests/hsm-test.rs
@@ -135,23 +135,17 @@ impl SecretKeyTrait for FakeHsm {
         let sig = self.sign_data.unwrap().1; // fake smartcard output
 
         let mpis = match self.public_key.algorithm() {
-            PublicKeyAlgorithm::RSA => vec![sig.into()],
+            PublicKeyAlgorithm::RSA => vec![Mpi::from_slice(sig)],
 
             PublicKeyAlgorithm::ECDSA => {
                 let mid = sig.len() / 2;
 
-                vec![
-                    Mpi::from_raw_slice(&sig[..mid]),
-                    Mpi::from_raw_slice(&sig[mid..]),
-                ]
+                vec![Mpi::from_slice(&sig[..mid]), Mpi::from_slice(&sig[mid..])]
             }
             PublicKeyAlgorithm::EdDSALegacy => {
                 assert_eq!(sig.len(), 64); // FIXME: check curve; add error handling
 
-                vec![
-                    Mpi::from_raw_slice(&sig[..32]),
-                    Mpi::from_raw_slice(&sig[32..]),
-                ]
+                vec![Mpi::from_slice(&sig[..32]), Mpi::from_slice(&sig[32..])]
             }
 
             _ => unimplemented!(),


### PR DESCRIPTION
This patch removes the MPI constructor which may be used to construct invalid MPIs. It also adjusts the `From<u8>` implementation to use a safe variant.

@hko-s please see if this is what we discussed. Thanks!

Fixes: https://github.com/rpgp/rpgp/issues/401