### PR TITLE
chore: remove unused and erratic end_of_line() fn

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -4,11 +4,10 @@ use std::ops::{Range, RangeFrom, RangeTo};
 use std::{hash, io};
 
 use byteorder::{BigEndian, WriteBytesExt};
-use nom::branch::alt;
 use nom::bytes::streaming::take_while1;
 use nom::character::is_alphanumeric;
 use nom::character::streaming::line_ending;
-use nom::combinator::{eof, map};
+use nom::combinator::map;
 use nom::multi::many0;
 use nom::number::streaming::{be_u32, be_u8};
 use nom::sequence::preceded;
@@ -136,10 +135,6 @@ pub fn write_packet_len(len: usize, writer: &mut impl io::Write) -> errors::Resu
     }
 
     Ok(())
-}
-
-pub fn end_of_line(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    alt((eof, end_of_line))(input)
 }
 
 /// Return the length of the remaining input.


### PR DESCRIPTION
- Looks like that is a typo left over from migrating `nom` to v7.
- Before migration, this was `alt!(input, eof!() | eol)`. 
- The migrated one looks wrongly (recursion eof).
- But anyway, this function is used nowhere, so remove it.