### PR TITLE
Relax dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.75"
 [dependencies]
 aes = "^0.8"
 argon2 = "0.5"
-base64 = "0.21.7, < 0.23"
+base64 = ">=0.21.7, < 0.23"
 bitfield = "0.14"
 block-padding = "^0.3.2"
 blowfish = "^0.9"
@@ -45,7 +45,7 @@ iter-read = "1"
 log = "0.4.6"
 md-5 = { version = "^0.10.5", features = ["oid"] }
 nom = "^7.0"
-num_enum = "0.5.7, < 0.8"
+num_enum = ">=0.5.7, < 0.8"
 num-traits = "0.2.6"
 p256 = { version = "^0.13", features = ["ecdsa", "ecdh"] }
 p384 = { version = "^0.13", features = ["ecdsa"] }


### PR DESCRIPTION
Following up on https://github.com/rpgp/rpgp/pull/397#issuecomment-2378096286 :

The rationale for https://github.com/rpgp/rpgp/pull/397 only mentioned needing the _option_ of older dependencies to build for Debian using Debian-packaged Rust libraries.  It didn't mention any reason to _force_ downgrades e.g. to improve security or stability or address a bug.

This PR relaxes those dependency requirements to avoid unnecessary dependency downgrades relative to `pgp` 0.13.2 for projects building with crates directly from crates.io.

Tests and stress tests pass locally, and `cargo deny` is ok locally.