### PR TITLE
test for possible buffer redux problem

### DIFF
--- a/src/composed/cleartext.rs
+++ b/src/composed/cleartext.rs
@@ -617,6 +617,14 @@ mod tests {
     }
 
     #[test]
+    fn test_load_big_csf() {
+        let msg_data = std::fs::read_to_string("./tests/unit-tests/csf-puppet/InRelease").unwrap();
+
+        // FIXME: this fails to read -> buffer_redux problem!?
+        let (_msg, _) = CleartextSignedMessage::from_armor(msg_data.as_bytes()).unwrap();
+    }
+
+    #[test]
     fn test_verify_csf_puppet() {
         // test data via https://github.com/rpgp/rpgp/issues/424
 


### PR DESCRIPTION
In this new test `test_load_big_csf`, a (valid) CSF message can't be loaded with `CleartextSignedMessage::from_armor`.
However, the same message can be loaded fine with `Any::from_string`.

I wonder if the reason is that `CleartextSignedMessage::from_armor` adds a second layer of `buffer_redux` (the problem seems to happen suspiciously close to the 8k bytes mark, which seems to be a default buffering amount in `buffer_redux`)

This PR is a reminder to debug what's going wrong in the `test_load_big_csf` test, and fix it.