### PR TITLE
feat: implement TryFrom<PublicOrSecret> for Signed{Public,Secret}Key

### DIFF
--- a/tests/hsm-test.rs
+++ b/tests/hsm-test.rs
@@ -11,7 +11,7 @@ use pgp::packet::{PacketTrait, PublicKey, SignatureConfig};
 use pgp::types::{EcdhPublicParams, EskType, Fingerprint, PkeskBytes, SignatureBytes};
 use pgp::types::{KeyId, Mpi, PublicKeyTrait, PublicParams, SecretKeyTrait};
 use pgp::{packet, Deserializable, Esk};
-use pgp::{Message, SignedPublicKey};
+use pgp::{Message, SignedPublicKey, SignedSecretKey};
 use rand::{CryptoRng, Rng};
 
 #[derive(Debug, Clone)]
@@ -344,7 +344,7 @@ fn card_decrypt() {
 
         let key_file = File::open(keyfile).unwrap();
         let (mut x, _) = pgp::composed::signed_key::from_reader_many(key_file).unwrap();
-        let key = x.next().unwrap().unwrap().into_secret();
+        let key: SignedSecretKey = x.next().unwrap().unwrap().try_into().unwrap();
 
         let pubkey: SignedPublicKey = key.into();
         let enc_subkey = &pubkey.public_subkeys.first().unwrap().key;
@@ -470,7 +470,7 @@ fn card_sign() {
 
         let key_file = File::open(keyfile).unwrap();
         let (mut x, _) = pgp::composed::signed_key::from_reader_many(key_file).unwrap();
-        let key = x.next().unwrap().unwrap().into_secret();
+        let key: SignedSecretKey = x.next().unwrap().unwrap().try_into().unwrap();
 
         let pubkey: SignedPublicKey = key.into();
 

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -1196,7 +1196,7 @@ fn test_parse_autocrypt_key(key: &str, unlock: bool) {
         parsed.verify().expect("invalid key");
 
         if unlock {
-            let sk = parsed.clone().into_secret();
+            let sk: SignedSecretKey = parsed.clone().try_into().unwrap();
             sk.unlock(|| "".to_string(), |_| Ok(()))
                 .expect("failed to unlock key");
 

--- a/tests/rfc9580.rs
+++ b/tests/rfc9580.rs
@@ -35,7 +35,7 @@ fn load_ssk(filename: &str) -> SignedSecretKey {
         pgp::composed::signed_key::from_reader_many(File::open(filename).unwrap()).expect("ok");
     let pos = iter.next().expect("some").expect("ok");
 
-    pos.into_secret()
+    pos.try_into().unwrap()
 }
 
 fn try_decrypt(keyfile: &str, msg_file: &str) {


### PR DESCRIPTION
This is less dangerous than checking
`is_public()` or `is_secret()`
and then using `into_secret()` and `into_public()` that may panic.