### PR TITLE
feat: derive Hash for KeyId

### DIFF
--- a/src/types/key_id.rs
+++ b/src/types/key_id.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::Result;
 
 /// Represents a Key ID.
-#[derive(Clone, Eq, PartialEq, derive_more::Debug)]
+#[derive(Clone, Hash, Eq, PartialEq, derive_more::Debug)]
 pub struct KeyId(#[debug("{}", hex::encode(_0))] [u8; 8]);
 
 impl AsRef<[u8]> for KeyId {


### PR DESCRIPTION
While `KeyId`s are mostly terrible and a legacy format, it can unfortunately still be useful to use them e.g. as keys in Maps, in weird edge cases.