### PR TITLE
ci: drop "Unicode-DFS-2016" from allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "MIT",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
     "Zlib"
 ]
 
@@ -22,5 +22,5 @@ license-files = [
 
 [advisories]
 ignore = [
-  "RUSTSEC-2023-0071" # Waiting for upstream fix
+    "RUSTSEC-2023-0071" # Waiting for upstream fix
 ]


### PR DESCRIPTION
That license doesn't seem to be needed anymore, and `cargo deny` complains about its unnecessary presence