### PR TITLE
feat! bump MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
         rust:
-          - nightly-2024-07-07
+          - nightly-2024-12-04
           - beta
           - stable
 
@@ -215,7 +215,7 @@ jobs:
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.75
+        toolchain: 1.81
         target: ${{ matrix.target }}
         override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "email"]
 exclude = ["tests/tests/*"]
 
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.81"
 
 [dependencies]
 aes = "^0.8"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <!-- msrv -->
   <a href="https://img.shields.io/badge/rustc-1.75+-blue.svg?style=flat-square">
     <img src="https://img.shields.io/badge/rustc-1.75+-blue.svg?style=flat-square"
-      alt="MSRV 1.75" />
+      alt="MSRV 1.81" />
   </a>
 </div>
 
@@ -131,7 +131,7 @@ Checkout [FAQ.md](docs/FAQ.md).
 
 ## Minimum Supported Rust Version (MSRV)
 
-All crates in this repository support Rust 1.75 or higher. In future minimally supported
+All crates in this repository support Rust 1.81 or higher. In future minimally supported
 version of Rust can be changed, but it will be done with a minor version bump.
 
 ## Funding
@@ -168,4 +168,4 @@ shall be dual licensed as above, without any additional terms or conditions.
 [`rsop`]: https://crates.io/crates/rsop/
 [`rpgpie`]: https://crates.io/crates/rpgpie
 [`rpm`]: https://crates.io/crates/rpm
-[`debian-packaging`]: https://crates.io/crates/debian-packaging 
+[`debian-packaging`]: https://crates.io/crates/debian-packaging


### PR DESCRIPTION
at least on dependency has silently upgraded to `1.81`, so we might as well make it explicit