### PR TITLE
feat!: implement feature gate for x448

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,12 @@ jobs:
         target: ${{ matrix.target }}
         args: --benches
 
+    - name: check curve448
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --features unstable-curve448 --all --target ${{ matrix.target }}
+
     - name: tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ nightly = ["rsa/nightly", "rand/nightly", "num-bigint/nightly"]
 profile = ["gperftools"]
 asm = ["sha1/asm", "sha2/asm", "md-5/asm"]
 wasm = ["chrono/wasmbind", "getrandom", "getrandom/js"]
-unstable-curve448 = ["x448"]
+unstable-curve448 = ["dep:x448"]
 
 [profile.bench]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ eax = "0.5.0"
 ocb3 = "0.1"
 aes-kw = { version = "0.2.1", features = ["std"] }
 derive_more = { version = "1.0.0-beta.6", features = ["debug"] }
-x448 = "0.6"
+x448 = { version = "0.6", optional = true }
 
 [dependencies.buffer-redux]
 version = "1.0.0"
@@ -128,6 +128,7 @@ nightly = ["rsa/nightly", "rand/nightly", "num-bigint/nightly"]
 profile = ["gperftools"]
 asm = ["sha1/asm", "sha2/asm", "md-5/asm"]
 wasm = ["chrono/wasmbind", "getrandom", "getrandom/js"]
+unstable-curve448 = ["x448"]
 
 [profile.bench]
 debug = 2

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ let public_key = SignedPublicKey::from_string(&key_string).unwrap().0;
 public_key.verify_signature(HashAlgorithm::default(), &data[..], &new_signature).unwrap();
 ```
 
+## Features
+
+### Experimental Cryptography
+
+Some cryptographic primitives are relatively new and under development.
+Those primitives are gated behind "unstable" features, so that they need to be explicitly enabled to make use of them.
+
+Currently, there is only one such feature:
+
+- The `unstable-curve448` enables public key encryption with the `x448` algorithm.
+
 ## Current Status
 
 > Last updated *September 2024*

--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -264,6 +264,7 @@ pub enum KeyType {
     /// Encrypting with X25519
     X25519,
     /// Encrypting with X448
+    #[cfg(feature = "x448")]
     X448,
 }
 
@@ -299,6 +300,7 @@ impl KeyType {
             KeyType::Dsa(_) => PublicKeyAlgorithm::DSA,
             KeyType::Ed25519 => PublicKeyAlgorithm::Ed25519,
             KeyType::X25519 => PublicKeyAlgorithm::X25519,
+            #[cfg(feature = "x448")]
             KeyType::X448 => PublicKeyAlgorithm::X448,
         }
     }
@@ -315,6 +317,7 @@ impl KeyType {
             KeyType::Dsa(key_size) => dsa::generate_key(rng, (*key_size).into())?,
             KeyType::Ed25519 => eddsa::generate_key(rng, eddsa::Mode::Ed25519),
             KeyType::X25519 => x25519::generate_key(rng),
+            #[cfg(feature = "x448")]
             KeyType::X448 => crate::crypto::x448::generate_key(rng),
         };
 

--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -264,7 +264,7 @@ pub enum KeyType {
     /// Encrypting with X25519
     X25519,
     /// Encrypting with X448
-    #[cfg(feature = "x448")]
+    #[cfg(feature = "unstable-curve448")]
     X448,
 }
 
@@ -300,7 +300,7 @@ impl KeyType {
             KeyType::Dsa(_) => PublicKeyAlgorithm::DSA,
             KeyType::Ed25519 => PublicKeyAlgorithm::Ed25519,
             KeyType::X25519 => PublicKeyAlgorithm::X25519,
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             KeyType::X448 => PublicKeyAlgorithm::X448,
         }
     }
@@ -317,7 +317,7 @@ impl KeyType {
             KeyType::Dsa(key_size) => dsa::generate_key(rng, (*key_size).into())?,
             KeyType::Ed25519 => eddsa::generate_key(rng, eddsa::Mode::Ed25519),
             KeyType::X25519 => x25519::generate_key(rng),
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             KeyType::X448 => crate::crypto::x448::generate_key(rng),
         };
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -16,6 +16,7 @@ pub mod public_key;
 pub mod rsa;
 pub mod sym;
 pub mod x25519;
+#[cfg(feature = "x448")]
 pub mod x448;
 
 pub trait Decryptor {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -16,7 +16,7 @@ pub mod public_key;
 pub mod rsa;
 pub mod sym;
 pub mod x25519;
-#[cfg(feature = "x448")]
+#[cfg(feature = "unstable-curve448")]
 pub mod x448;
 
 pub trait Decryptor {

--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -458,6 +458,7 @@ impl PublicKeyTrait for PubKeyInner {
             PublicParams::X25519 { .. } => {
                 bail!("X25519 can not be used for verify operations");
             }
+            #[cfg(feature = "x448")]
             PublicParams::X448 { .. } => {
                 bail!("X448 can not be used for verify operations");
             }
@@ -579,6 +580,7 @@ impl PublicKeyTrait for PubKeyInner {
                     sym_alg,
                 })
             }
+            #[cfg(feature = "x448")]
             PublicParams::X448 { ref public } => {
                 let (sym_alg, plain) = match typ {
                     EskType::V6 => (None, plain),

--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -458,7 +458,7 @@ impl PublicKeyTrait for PubKeyInner {
             PublicParams::X25519 { .. } => {
                 bail!("X25519 can not be used for verify operations");
             }
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PublicParams::X448 { .. } => {
                 bail!("X448 can not be used for verify operations");
             }
@@ -580,7 +580,7 @@ impl PublicKeyTrait for PubKeyInner {
                     sym_alg,
                 })
             }
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PublicParams::X448 { ref public } => {
                 let (sym_alg, plain) = match typ {
                     EskType::V6 => (None, plain),

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -276,6 +276,7 @@ impl<D: PublicKeyTrait + PacketTrait + Clone + crate::ser::Serialize> SecretKeyT
                 SecretKeyRepr::X25519(_) => {
                     bail!("X25519 can not be used for signing operations")
                 }
+                #[cfg(feature = "x448")]
                 SecretKeyRepr::X448(_) => {
                     bail!("X448 can not be used for signing operations")
                 }

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -276,7 +276,7 @@ impl<D: PublicKeyTrait + PacketTrait + Clone + crate::ser::Serialize> SecretKeyT
                 SecretKeyRepr::X25519(_) => {
                     bail!("X25519 can not be used for signing operations")
                 }
-                #[cfg(feature = "x448")]
+                #[cfg(feature = "unstable-curve448")]
                 SecretKeyRepr::X448(_) => {
                     bail!("X448 can not be used for signing operations")
                 }

--- a/src/packet/public_key_encrypted_session_key.rs
+++ b/src/packet/public_key_encrypted_session_key.rs
@@ -79,7 +79,9 @@ impl PublicKeyEncryptedSessionKey {
 
         // Appended a checksum of the session key (except for X25519 and X448)
         match pp {
-            PublicParams::X25519 { .. } | PublicParams::X448 { .. } => {}
+            PublicParams::X25519 { .. } => {}
+            #[cfg(feature = "x448")]
+            PublicParams::X448 { .. } => {}
             _ => data.extend_from_slice(&checksum::calculate_simple(sk).to_be_bytes()),
         }
 
@@ -268,6 +270,7 @@ fn parse_esk<'i>(
                 },
             ))
         }
+        #[cfg(feature = "x448")]
         PublicKeyAlgorithm::X448 => {
             // 56 octets representing an ephemeral X448 public key.
             let (i, ephemeral_public) = nom::bytes::complete::take(56u8)(i)?;
@@ -489,6 +492,7 @@ impl Serialize for PublicKeyEncryptedSessionKey {
 
                 writer.write_all(session_key)?; // encrypted session key
             }
+            #[cfg(feature = "x448")]
             (
                 PublicKeyAlgorithm::X448,
                 PkeskBytes::X448 {

--- a/src/packet/public_key_encrypted_session_key.rs
+++ b/src/packet/public_key_encrypted_session_key.rs
@@ -80,7 +80,7 @@ impl PublicKeyEncryptedSessionKey {
         // Appended a checksum of the session key (except for X25519 and X448)
         match pp {
             PublicParams::X25519 { .. } => {}
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PublicParams::X448 { .. } => {}
             _ => data.extend_from_slice(&checksum::calculate_simple(sk).to_be_bytes()),
         }
@@ -270,7 +270,7 @@ fn parse_esk<'i>(
                 },
             ))
         }
-        #[cfg(feature = "x448")]
+        #[cfg(feature = "unstable-curve448")]
         PublicKeyAlgorithm::X448 => {
             // 56 octets representing an ephemeral X448 public key.
             let (i, ephemeral_public) = nom::bytes::complete::take(56u8)(i)?;
@@ -492,7 +492,7 @@ impl Serialize for PublicKeyEncryptedSessionKey {
 
                 writer.write_all(session_key)?; // encrypted session key
             }
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             (
                 PublicKeyAlgorithm::X448,
                 PkeskBytes::X448 {

--- a/src/packet/public_key_parser.rs
+++ b/src/packet/public_key_parser.rs
@@ -80,6 +80,7 @@ fn x25519(i: &[u8]) -> IResult<&[u8], PublicParams> {
 }
 
 /// <https://www.rfc-editor.org/rfc/rfc9580.html#name-algorithm-specific-part-for-x4>
+#[cfg(feature = "x448")]
 fn x448(i: &[u8]) -> IResult<&[u8], PublicParams> {
     // 56 bytes of public key
     let (i, p) = nom::bytes::complete::take(56u8)(i)?;
@@ -200,7 +201,10 @@ pub fn parse_pub_fields(
         PublicKeyAlgorithm::Ed25519 => ed25519(i),
         PublicKeyAlgorithm::X25519 => x25519(i),
         PublicKeyAlgorithm::Ed448 => unknown(i, len), // FIXME: implement later
+        #[cfg(feature = "x448")]
         PublicKeyAlgorithm::X448 => x448(i),
+        #[cfg(not(feature = "x448"))]
+        PublicKeyAlgorithm::X448 => unknown(i, len),
 
         PublicKeyAlgorithm::DiffieHellman
         | PublicKeyAlgorithm::Private100

--- a/src/packet/public_key_parser.rs
+++ b/src/packet/public_key_parser.rs
@@ -80,7 +80,7 @@ fn x25519(i: &[u8]) -> IResult<&[u8], PublicParams> {
 }
 
 /// <https://www.rfc-editor.org/rfc/rfc9580.html#name-algorithm-specific-part-for-x4>
-#[cfg(feature = "x448")]
+#[cfg(feature = "unstable-curve448")]
 fn x448(i: &[u8]) -> IResult<&[u8], PublicParams> {
     // 56 bytes of public key
     let (i, p) = nom::bytes::complete::take(56u8)(i)?;
@@ -201,9 +201,9 @@ pub fn parse_pub_fields(
         PublicKeyAlgorithm::Ed25519 => ed25519(i),
         PublicKeyAlgorithm::X25519 => x25519(i),
         PublicKeyAlgorithm::Ed448 => unknown(i, len), // FIXME: implement later
-        #[cfg(feature = "x448")]
+        #[cfg(feature = "unstable-curve448")]
         PublicKeyAlgorithm::X448 => x448(i),
-        #[cfg(not(feature = "x448"))]
+        #[cfg(not(feature = "unstable-curve448"))]
         PublicKeyAlgorithm::X448 => unknown(i, len),
 
         PublicKeyAlgorithm::DiffieHellman

--- a/src/types/params/plain_secret.rs
+++ b/src/types/params/plain_secret.rs
@@ -38,7 +38,7 @@ pub enum PlainSecretParams {
     EdDSALegacy(#[debug("..")] Mpi),
     Ed25519(#[debug("..")] [u8; 32]),
     X25519(#[debug("..")] [u8; 32]),
-    #[cfg(feature = "x448")]
+    #[cfg(feature = "unstable-curve448")]
     X448(#[debug("..")] [u8; 56]),
 }
 
@@ -61,7 +61,7 @@ pub enum PlainSecretParamsRef<'a> {
     EdDSALegacy(#[debug("..")] MpiRef<'a>),
     Ed25519(#[debug("..")] &'a [u8; 32]),
     X25519(#[debug("..")] &'a [u8; 32]),
-    #[cfg(feature = "x448")]
+    #[cfg(feature = "unstable-curve448")]
     X448(#[debug("..")] &'a [u8; 56]),
 }
 
@@ -81,7 +81,7 @@ impl PlainSecretParamsRef<'_> {
             PlainSecretParamsRef::EdDSALegacy(v) => PlainSecretParams::EdDSALegacy((*v).to_owned()),
             PlainSecretParamsRef::Ed25519(s) => PlainSecretParams::Ed25519((*s).to_owned()),
             PlainSecretParamsRef::X25519(s) => PlainSecretParams::X25519((*s).to_owned()),
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PlainSecretParamsRef::X448(s) => PlainSecretParams::X448((*s).to_owned()),
         }
     }
@@ -119,7 +119,7 @@ impl PlainSecretParamsRef<'_> {
             PlainSecretParamsRef::X25519(s) => {
                 writer.write_all(&s[..])?;
             }
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PlainSecretParamsRef::X448(s) => {
                 writer.write_all(&s[..])?;
             }
@@ -257,7 +257,7 @@ impl PlainSecretParamsRef<'_> {
                     secret: **d,
                 }))
             }
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PlainSecretParamsRef::X448(d) => {
                 Ok(SecretKeyRepr::X448(crate::crypto::x448::SecretKey {
                     secret: **d,
@@ -347,7 +347,7 @@ impl PlainSecretParams {
             PlainSecretParams::EdDSALegacy(v) => PlainSecretParamsRef::EdDSALegacy(v.as_ref()),
             PlainSecretParams::Ed25519(s) => PlainSecretParamsRef::Ed25519(s),
             PlainSecretParams::X25519(s) => PlainSecretParamsRef::X25519(s),
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PlainSecretParams::X448(s) => PlainSecretParamsRef::X448(s),
         }
     }
@@ -497,7 +497,7 @@ fn parse_secret_params(
             let (i, s) = nom::bytes::complete::take(32u8)(i)?;
             Ok((i, PlainSecretParams::X25519(s.try_into().expect("32"))))
         }
-        #[cfg(feature = "x448")]
+        #[cfg(feature = "unstable-curve448")]
         PublicKeyAlgorithm::X448 => {
             let (i, s) = nom::bytes::complete::take(56u8)(i)?;
             Ok((i, PlainSecretParams::X448(s.try_into().expect("56"))))

--- a/src/types/params/plain_secret.rs
+++ b/src/types/params/plain_secret.rs
@@ -38,6 +38,7 @@ pub enum PlainSecretParams {
     EdDSALegacy(#[debug("..")] Mpi),
     Ed25519(#[debug("..")] [u8; 32]),
     X25519(#[debug("..")] [u8; 32]),
+    #[cfg(feature = "x448")]
     X448(#[debug("..")] [u8; 56]),
 }
 
@@ -60,6 +61,7 @@ pub enum PlainSecretParamsRef<'a> {
     EdDSALegacy(#[debug("..")] MpiRef<'a>),
     Ed25519(#[debug("..")] &'a [u8; 32]),
     X25519(#[debug("..")] &'a [u8; 32]),
+    #[cfg(feature = "x448")]
     X448(#[debug("..")] &'a [u8; 56]),
 }
 
@@ -79,6 +81,7 @@ impl PlainSecretParamsRef<'_> {
             PlainSecretParamsRef::EdDSALegacy(v) => PlainSecretParams::EdDSALegacy((*v).to_owned()),
             PlainSecretParamsRef::Ed25519(s) => PlainSecretParams::Ed25519((*s).to_owned()),
             PlainSecretParamsRef::X25519(s) => PlainSecretParams::X25519((*s).to_owned()),
+            #[cfg(feature = "x448")]
             PlainSecretParamsRef::X448(s) => PlainSecretParams::X448((*s).to_owned()),
         }
     }
@@ -116,6 +119,7 @@ impl PlainSecretParamsRef<'_> {
             PlainSecretParamsRef::X25519(s) => {
                 writer.write_all(&s[..])?;
             }
+            #[cfg(feature = "x448")]
             PlainSecretParamsRef::X448(s) => {
                 writer.write_all(&s[..])?;
             }
@@ -253,6 +257,7 @@ impl PlainSecretParamsRef<'_> {
                     secret: **d,
                 }))
             }
+            #[cfg(feature = "x448")]
             PlainSecretParamsRef::X448(d) => {
                 Ok(SecretKeyRepr::X448(crate::crypto::x448::SecretKey {
                     secret: **d,
@@ -342,6 +347,7 @@ impl PlainSecretParams {
             PlainSecretParams::EdDSALegacy(v) => PlainSecretParamsRef::EdDSALegacy(v.as_ref()),
             PlainSecretParams::Ed25519(s) => PlainSecretParamsRef::Ed25519(s),
             PlainSecretParams::X25519(s) => PlainSecretParamsRef::X25519(s),
+            #[cfg(feature = "x448")]
             PlainSecretParams::X448(s) => PlainSecretParamsRef::X448(s),
         }
     }
@@ -491,6 +497,7 @@ fn parse_secret_params(
             let (i, s) = nom::bytes::complete::take(32u8)(i)?;
             Ok((i, PlainSecretParams::X25519(s.try_into().expect("32"))))
         }
+        #[cfg(feature = "x448")]
         PublicKeyAlgorithm::X448 => {
             let (i, s) = nom::bytes::complete::take(56u8)(i)?;
             Ok((i, PlainSecretParams::X448(s.try_into().expect("56"))))

--- a/src/types/params/public.rs
+++ b/src/types/params/public.rs
@@ -20,6 +20,7 @@ pub enum PublicParams {
     EdDSALegacy { curve: ECCCurve, q: Mpi },
     Ed25519 { public: [u8; 32] },
     X25519 { public: [u8; 32] },
+    #[cfg(feature = "x448")]
     X448 { public: [u8; 56] },
     Unknown { data: Vec<u8> },
 }
@@ -236,6 +237,7 @@ impl Serialize for PublicParams {
             PublicParams::X25519 { ref public } => {
                 writer.write_all(&public[..])?;
             }
+            #[cfg(feature = "x448")]
             PublicParams::X448 { ref public } => {
                 writer.write_all(&public[..])?;
             }

--- a/src/types/params/public.rs
+++ b/src/types/params/public.rs
@@ -20,7 +20,7 @@ pub enum PublicParams {
     EdDSALegacy { curve: ECCCurve, q: Mpi },
     Ed25519 { public: [u8; 32] },
     X25519 { public: [u8; 32] },
-    #[cfg(feature = "x448")]
+    #[cfg(feature = "unstable-curve448")]
     X448 { public: [u8; 56] },
     Unknown { data: Vec<u8> },
 }
@@ -237,7 +237,7 @@ impl Serialize for PublicParams {
             PublicParams::X25519 { ref public } => {
                 writer.write_all(&public[..])?;
             }
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             PublicParams::X448 { ref public } => {
                 writer.write_all(&public[..])?;
             }

--- a/src/types/params/public.rs
+++ b/src/types/params/public.rs
@@ -12,17 +12,40 @@ use crate::types::{Mpi, MpiRef};
 /// Represent the public parameters for the different algorithms.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum PublicParams {
-    RSA { n: Mpi, e: Mpi },
-    DSA { p: Mpi, q: Mpi, g: Mpi, y: Mpi },
+    RSA {
+        n: Mpi,
+        e: Mpi,
+    },
+    DSA {
+        p: Mpi,
+        q: Mpi,
+        g: Mpi,
+        y: Mpi,
+    },
     ECDSA(EcdsaPublicParams),
     ECDH(EcdhPublicParams),
-    Elgamal { p: Mpi, g: Mpi, y: Mpi },
-    EdDSALegacy { curve: ECCCurve, q: Mpi },
-    Ed25519 { public: [u8; 32] },
-    X25519 { public: [u8; 32] },
+    Elgamal {
+        p: Mpi,
+        g: Mpi,
+        y: Mpi,
+    },
+    EdDSALegacy {
+        curve: ECCCurve,
+        q: Mpi,
+    },
+    Ed25519 {
+        public: [u8; 32],
+    },
+    X25519 {
+        public: [u8; 32],
+    },
     #[cfg(feature = "unstable-curve448")]
-    X448 { public: [u8; 56] },
-    Unknown { data: Vec<u8> },
+    X448 {
+        public: [u8; 56],
+    },
+    Unknown {
+        data: Vec<u8>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/types/secret_key_repr.rs
+++ b/src/types/secret_key_repr.rs
@@ -18,6 +18,7 @@ pub enum SecretKeyRepr {
     ECDH(ecdh::SecretKey),
     EdDSA(eddsa::SecretKey),
     X25519(x25519::SecretKey),
+    #[cfg(feature = "x448")]
     X448(crate::crypto::x448::SecretKey),
 }
 
@@ -79,6 +80,7 @@ impl SecretKeyRepr {
                 };
             }
 
+            #[cfg(feature = "x448")]
             (
                 SecretKeyRepr::X448(ref priv_key),
                 PkeskBytes::X448 {

--- a/src/types/secret_key_repr.rs
+++ b/src/types/secret_key_repr.rs
@@ -18,7 +18,7 @@ pub enum SecretKeyRepr {
     ECDH(ecdh::SecretKey),
     EdDSA(eddsa::SecretKey),
     X25519(x25519::SecretKey),
-    #[cfg(feature = "x448")]
+    #[cfg(feature = "unstable-curve448")]
     X448(crate::crypto::x448::SecretKey),
 }
 
@@ -80,7 +80,7 @@ impl SecretKeyRepr {
                 };
             }
 
-            #[cfg(feature = "x448")]
+            #[cfg(feature = "unstable-curve448")]
             (
                 SecretKeyRepr::X448(ref priv_key),
                 PkeskBytes::X448 {

--- a/tests/rfc9580.rs
+++ b/tests/rfc9580.rs
@@ -16,6 +16,7 @@ const MSG: &str = "hello world\n";
 // Test cases based on keys with new formats from RFC9580
 const CASES_9580: &[&str] = &[
     ("tests/rfc9580/v6-25519-annex-a-4"), // TSK from RFC 9580 Annex A.4 (Ed25519/X25519)
+    #[cfg(feature = "x448")]
     ("tests/rfc9580/v6-ed25519-x448"), // TSK using Ed25519/X448 (TODO: replace with Ed448/X448 once rPGP supports it)
     ("tests/rfc9580/v6-rsa"),          // TSK using RSA
     ("tests/rfc9580/v6-nistp"),        // TSK using NIST P-256

--- a/tests/rfc9580.rs
+++ b/tests/rfc9580.rs
@@ -16,7 +16,7 @@ const MSG: &str = "hello world\n";
 // Test cases based on keys with new formats from RFC9580
 const CASES_9580: &[&str] = &[
     ("tests/rfc9580/v6-25519-annex-a-4"), // TSK from RFC 9580 Annex A.4 (Ed25519/X25519)
-    #[cfg(feature = "x448")]
+    #[cfg(feature = "unstable-curve448")]
     ("tests/rfc9580/v6-ed25519-x448"), // TSK using Ed25519/X448 (TODO: replace with Ed448/X448 once rPGP supports it)
     ("tests/rfc9580/v6-rsa"),          // TSK using RSA
     ("tests/rfc9580/v6-nistp"),        // TSK using NIST P-256

--- a/tests/rfc9580.rs
+++ b/tests/rfc9580.rs
@@ -18,8 +18,8 @@ const CASES_9580: &[&str] = &[
     ("tests/rfc9580/v6-25519-annex-a-4"), // TSK from RFC 9580 Annex A.4 (Ed25519/X25519)
     #[cfg(feature = "unstable-curve448")]
     ("tests/rfc9580/v6-ed25519-x448"), // TSK using Ed25519/X448 (TODO: replace with Ed448/X448 once rPGP supports it)
-    ("tests/rfc9580/v6-rsa"),          // TSK using RSA
-    ("tests/rfc9580/v6-nistp"),        // TSK using NIST P-256
+    ("tests/rfc9580/v6-rsa"),            // TSK using RSA
+    ("tests/rfc9580/v6-nistp"),          // TSK using NIST P-256
     ("tests/rfc9580/v4-ed25519-x25519"), // Version 4 TSK using the RFC 9580 Ed25519/X25519 formats
 ];
 

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -202,6 +202,7 @@ fn rpg_021_signed_secret_key_encrypt_panic1() {
 }
 
 /// RPG-021
+#[cfg(feature = "unstable-curve448")]
 #[test]
 fn rpg_021_signed_secret_key_encrypt_panic2() {
     let bad_input: &[u8] = &[


### PR DESCRIPTION
## Breaking Changes

- `x448` support is now disabled by default and gated behind a feature flag `unstable-curve448`