### PR TITLE
xx: make seipd Config public

### DIFF
--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -81,7 +81,7 @@ mod padding;
 mod public_key_encrypted_session_key;
 mod signature;
 mod sym_encrypted_data;
-mod sym_encrypted_protected_data;
+pub mod sym_encrypted_protected_data;
 mod sym_key_encrypted_session_key;
 mod trust;
 mod user_attribute;

--- a/src/packet/sym_encrypted_protected_data.rs
+++ b/src/packet/sym_encrypted_protected_data.rs
@@ -19,7 +19,7 @@ use crate::types::Tag;
 #[derive(Clone, PartialEq, Eq, derive_more::Debug)]
 pub struct SymEncryptedProtectedData {
     packet_header: PacketHeader,
-    config: Config,
+    pub config: Config,
     #[debug("{}", hex::encode(data))]
     data: Bytes,
 }


### PR DESCRIPTION
This is just a note to say that I need to access the SEIPD Config from rpgpie.

I expect you want to re-export it from `src/packet/mod.rs`. In that case, I think it needs a more expressive name. Maybe `SeipdConfig`?