### PR TITLE
build: Make `cargo` not pull the tests submodule when referencing rpgp via git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Checkout submodules
+      run: git submodule update --checkout
+
     - name: Install ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1
       with:
@@ -75,6 +78,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Checkout submodules
+      run: git submodule update --checkout
+
     - name: Install ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1
       with:
@@ -114,6 +120,9 @@ jobs:
       uses: actions/checkout@master
       with:
         submodules: recursive
+
+    - name: Checkout submodules
+      run: git submodule update --checkout
 
     - name: Install stable
       uses: actions-rs/toolchain@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests/tests"]
 	path = tests/tests
 	url = https://github.com/rpgp/tests.git
+	update = none


### PR DESCRIPTION
Currently, using a pre-release git dependency in Cargo.toml makes cargo pull the tests directory as well which results in gigantic, unnecessary traffic.

```toml
[dependencies]
pgp = { git = "https://github.com/rpgp/rpgp" }
```

This patch disables pulling the tests by default and makes cargo skip the submodule:

```sh
$ cargo build
    Updating git repository `https://github.com/rpgp/rpgp`
    Skipping git submodule `https://github.com/rpgp/tests.git` due to update strategy in .gitmodules
```

See: https://github.com/rust-lang/cargo/issues/4247#issuecomment-1149178736