### PR TITLE
mpi minor cleanup

### DIFF
--- a/src/types/mpi.rs
+++ b/src/types/mpi.rs
@@ -35,7 +35,9 @@ impl MpiBytes {
         self.0.is_empty()
     }
 
-    /// Parses the given buffer for an MPI.
+    /// Parses the given buffer as an MPI.
+    ///
+    /// The buffer is expected to be length-prefixed.
     pub fn from_buf<B: bytes::Buf>(mut i: B) -> Result<Self> {
         let len_bits = i.read_be_u16()?;
 
@@ -52,6 +54,9 @@ impl MpiBytes {
         Ok(MpiBytes(n_stripped))
     }
 
+    /// Represent the data in `raw` as an Mpi.
+    /// Note that `raw` is not expected to be length-prefixed!
+    ///
     /// Strips leading zeros.
     pub fn from_slice(raw: &[u8]) -> Self {
         Self(strip_leading_zeros(raw).to_vec().into())

--- a/src/types/mpi.rs
+++ b/src/types/mpi.rs
@@ -10,7 +10,7 @@ use crate::ser::Serialize;
 
 /// Number of bits we accept when reading or writing MPIs.
 /// The value is the same as gnupgs.
-const MAX_EXTERN_MPI_BITS: u32 = 16384;
+const MAX_EXTERN_MPI_BITS: u16 = 16384;
 
 /// Represents an owned MPI value.
 /// The inner value is ready to be serialized, without the need to strip leading zeros.
@@ -37,16 +37,15 @@ impl MpiBytes {
 
     /// Parses the given buffer for an MPI.
     pub fn from_buf<B: bytes::Buf>(mut i: B) -> Result<Self> {
-        let len = i.read_be_u16()?;
+        let len_bits = i.read_be_u16()?;
 
-        let bits = u32::from(len);
-        let len_actual = (bits + 7) >> 3;
-
-        if len_actual > MAX_EXTERN_MPI_BITS {
+        if len_bits > MAX_EXTERN_MPI_BITS {
             return Err(Error::InvalidInput);
         }
 
-        let n = i.read_take(len_actual.try_into()?)?;
+        let len_bytes = (len_bits + 7) >> 3;
+
+        let n = i.read_take(usize::from(len_bytes))?;
         let n_stripped = strip_leading_zeros(&n);
         let n_stripped = n.slice_ref(n_stripped);
 
@@ -118,9 +117,9 @@ impl From<MpiBytes> for BigUint {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use proptest::prelude::*;
+
+    use super::*;
 
     impl Arbitrary for MpiBytes {
         type Parameters = ();

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -159,10 +159,10 @@ parse_dumps!(
     (
         test_parse_dumps_0,
         0,
-        17_730,
+        17_728,
         // Hash::Other(4)
         1,
-        3264,
+        3266,
         20_995
     ),
     (
@@ -183,8 +183,8 @@ parse_dumps!(
         // - Hash::Other(5)
         // - Elgamal verify
         5,
-        3389,
-        20_993
+        3390,
+        20_994
     ),
     (
         test_parse_dumps_3,
@@ -212,8 +212,8 @@ parse_dumps!(
         // - Hash::Other(4)
         // - Elgamal verify
         8,
-        3346,
-        20_998
+        3349,
+        21_001
     ),
     (
         test_parse_dumps_6,
@@ -250,8 +250,8 @@ parse_dumps!(
         // - Hash::Other(5)
         // - Elgamal verify
         3,
-        3420,
-        20_999
+        3421,
+        21_000
     ),
 );
 


### PR DESCRIPTION
I found the naming a bit confusing, and the casting seems needlessly complicated too (?).

Also, i think the comparison with MAX_EXTERN_MPI_BITS was wrong (it compared bytes against bits), so the limit was ineffective.