### PR TITLE
ci: run doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
     - name: tests
       run: cargo nextest run --lib --bins --tests --all
 
+    - name: doc tests
+      run: cargo test --doc
+
     - name: asm
       if: ${{ matrix.rust == env.RUST_NIGHTLY }}
       run: cargo nextest run --lib --bins --tests --all --features asm


### PR DESCRIPTION
nextest doesn't currently run doctests, also see https://github.com/rpgp/rpgp/pull/455#issuecomment-2703215294