### PR TITLE
fix: check that fixed part is as long as it claims to be

### DIFF
--- a/src/composed/message/reader/limited.rs
+++ b/src/composed/message/reader/limited.rs
@@ -2,11 +2,7 @@ use std::io::{self, BufRead, Read};
 
 #[derive(Debug)]
 pub enum LimitedReader<R: BufRead> {
-    Fixed {
-        // Number of bytes we (still) expect to read from this Fixed
-        expect_data: u32,
-        reader: io::Take<R>,
-    },
+    Fixed { reader: io::Take<R> },
     Indeterminate(R),
     Partial(io::Take<R>),
 }
@@ -22,7 +18,7 @@ impl<R: BufRead> BufRead for LimitedReader<R> {
 
     fn consume(&mut self, amt: usize) {
         match self {
-            Self::Fixed { reader, .. } => {
+            Self::Fixed { reader } => {
                 reader.consume(amt);
             }
             Self::Indeterminate(ref mut r) => r.consume(amt),
@@ -34,21 +30,7 @@ impl<R: BufRead> BufRead for LimitedReader<R> {
 impl<R: BufRead> Read for LimitedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            Self::Fixed {
-                reader,
-                expect_data,
-            } => {
-                let got = reader.read(buf)?;
-                if got > *expect_data as usize {
-                    // This should never happen: LimitedReader should never read more than expect_data
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Got more data than expected",
-                    ));
-                }
-                *expect_data -= u32::try_from(got).expect("checked, cannot be too large");
-                Ok(got)
-            }
+            Self::Fixed { reader } => reader.read(buf),
             Self::Indeterminate(ref mut r) => r.read(buf),
             Self::Partial(ref mut r) => r.read(buf),
         }
@@ -56,12 +38,9 @@ impl<R: BufRead> Read for LimitedReader<R> {
 }
 
 impl<R: BufRead> LimitedReader<R> {
-    pub fn fixed(limit: u32, reader: R) -> Self {
-        let reader = reader.take(limit as u64);
-        Self::Fixed {
-            reader,
-            expect_data: limit,
-        }
+    pub fn fixed(limit: u64, reader: R) -> Self {
+        let reader = reader.take(limit);
+        Self::Fixed { reader }
     }
 
     pub fn into_inner(self) -> R {

--- a/src/composed/message/reader/limited.rs
+++ b/src/composed/message/reader/limited.rs
@@ -2,7 +2,11 @@ use std::io::{self, BufRead, Read};
 
 #[derive(Debug)]
 pub enum LimitedReader<R: BufRead> {
-    Fixed { reader: io::Take<R> },
+    Fixed {
+        // Number of bytes we (still) expect to read from this Fixed
+        expect_data: u32,
+        reader: io::Take<R>,
+    },
     Indeterminate(R),
     Partial(io::Take<R>),
 }
@@ -18,7 +22,7 @@ impl<R: BufRead> BufRead for LimitedReader<R> {
 
     fn consume(&mut self, amt: usize) {
         match self {
-            Self::Fixed { reader } => {
+            Self::Fixed { reader, .. } => {
                 reader.consume(amt);
             }
             Self::Indeterminate(ref mut r) => r.consume(amt),
@@ -30,7 +34,21 @@ impl<R: BufRead> BufRead for LimitedReader<R> {
 impl<R: BufRead> Read for LimitedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            Self::Fixed { reader } => reader.read(buf),
+            Self::Fixed {
+                reader,
+                expect_data,
+            } => {
+                let got = reader.read(buf)?;
+                if got > *expect_data as usize {
+                    // This should never happen: LimitedReader should never read more than expect_data
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "Got more data than expected",
+                    ));
+                }
+                *expect_data -= u32::try_from(got).expect("checked, cannot be too large");
+                Ok(got)
+            }
             Self::Indeterminate(ref mut r) => r.read(buf),
             Self::Partial(ref mut r) => r.read(buf),
         }
@@ -38,9 +56,12 @@ impl<R: BufRead> Read for LimitedReader<R> {
 }
 
 impl<R: BufRead> LimitedReader<R> {
-    pub fn fixed(limit: u64, reader: R) -> Self {
-        let reader = reader.take(limit);
-        Self::Fixed { reader }
+    pub fn fixed(limit: u32, reader: R) -> Self {
+        let reader = reader.take(limit as u64);
+        Self::Fixed {
+            reader,
+            expect_data: limit,
+        }
     }
 
     pub fn into_inner(self) -> R {

--- a/tests/message_test.rs
+++ b/tests/message_test.rs
@@ -603,7 +603,8 @@ fn test_invalid_partial_messages() {
     dbg!(&err);
 
     assert!(
-        err.to_string().contains("unexpected trailing"),
+        err.to_string()
+            .contains("Unexpectedly short final Fixed chunk"),
         "found error: {}",
         err
     );

--- a/tests/message_test.rs
+++ b/tests/message_test.rs
@@ -604,7 +604,7 @@ fn test_invalid_partial_messages() {
 
     assert!(
         err.to_string()
-            .contains("Unexpectedly short final Fixed chunk"),
+            .contains("Unexpected trailing data in final Fixed chunk"),
         "found error: {}",
         err
     );


### PR DESCRIPTION
This is tested in the interop suite for the final fixed chunk in partial encoded bodies.