### PR TITLE
guardrails against sed packet decryption

### DIFF
--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -490,9 +490,32 @@ impl<'a> Edata<'a> {
         }
     }
 
-    pub fn decrypt(&mut self, key: &PlainSessionKey) -> Result<()> {
+    /// Decrypts only SEIPD (v1 or v2), errors for SED packets
+    /// (this avoids decrypting malleable ciphertext)
+    pub fn decrypt_protected(&mut self, key: &PlainSessionKey) -> Result<()> {
         let protected = self.tag() == Tag::SymEncryptedProtectedData;
-        debug!("decrypting protected = {:?}", protected);
+        debug!("decrypt_protected: protected = {:?}", protected);
+
+        match self {
+            Self::SymEncryptedProtectedData { reader } => {
+                reader.decrypt(key)?;
+            }
+            Self::SymEncryptedData { .. } => {
+                // SED packets are malleable, decrypting them should only be necessary for historical data
+                bail!("Decryption of SymEncryptedData is discouraged")
+            }
+        }
+
+        Ok(())
+    }
+
+    /// HAZMAT: Decrypts SEIPD (v1 or v2) and SED packets.
+    ///
+    /// Decrypting (malleable) SED packets is not necessary for most use cases, except for
+    /// historical data.
+    pub fn decrypt_any(&mut self, key: &PlainSessionKey) -> Result<()> {
+        let protected = self.tag() == Tag::SymEncryptedProtectedData;
+        debug!("decrypt_any: protected = {:?}", protected);
 
         match self {
             Self::SymEncryptedProtectedData { reader } => {
@@ -761,7 +784,7 @@ impl<'a> Message<'a> {
                     return Err(Error::MissingKey);
                 };
 
-                edata.decrypt(&session_key)?;
+                edata.decrypt_protected(&session_key)?;
                 let source = MessageReader::Edata(Box::new(edata));
                 let message = Message::internal_from_bytes(source, is_nested)?;
                 Ok((message, result))

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -492,7 +492,7 @@ impl<'a> Edata<'a> {
 
     /// Decrypts only SEIPD (v1 or v2), errors for SED packets
     /// (this avoids decrypting malleable ciphertext)
-    pub fn decrypt_protected(&mut self, key: &PlainSessionKey) -> Result<()> {
+    pub fn decrypt(&mut self, key: &PlainSessionKey) -> Result<()> {
         let protected = self.tag() == Tag::SymEncryptedProtectedData;
         debug!("decrypt_protected: protected = {:?}", protected);
 
@@ -513,7 +513,7 @@ impl<'a> Edata<'a> {
     ///
     /// Decrypting (malleable) SED packets is not necessary for most use cases, except for
     /// historical data.
-    pub fn decrypt_any(&mut self, key: &PlainSessionKey) -> Result<()> {
+    pub fn decrypt_legacy(&mut self, key: &PlainSessionKey) -> Result<()> {
         let protected = self.tag() == Tag::SymEncryptedProtectedData;
         debug!("decrypt_any: protected = {:?}", protected);
 
@@ -784,7 +784,7 @@ impl<'a> Message<'a> {
                     return Err(Error::MissingKey);
                 };
 
-                edata.decrypt_protected(&session_key)?;
+                edata.decrypt(&session_key)?;
                 let source = MessageReader::Edata(Box::new(edata));
                 let message = Message::internal_from_bytes(source, is_nested)?;
                 Ok((message, result))


### PR DESCRIPTION
We should probably not decrypt SED packets by default.

But I'm not sure how best to expose this in the API. Thoughts welcome.