### PR TITLE
errors: lower enum size from 120 bytes to 80

### DIFF
--- a/src/packet/single.rs
+++ b/src/packet/single.rs
@@ -111,7 +111,7 @@ impl Packet {
                 if source.kind() == std::io::ErrorKind::UnexpectedEof =>
             {
                 Err(Error::PacketIncomplete {
-                    source: crate::parsing::Error::UnexpectedEof { source, backtrace },
+                    source: Box::new(crate::parsing::Error::UnexpectedEof { source, backtrace }),
                 })
             }
             Err(err) => {


### PR DESCRIPTION
This lowers the size of the Error enum from 120 bytes to 80 bytes to steer away from the limit checked by clippy (128 bytes): https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

Fixes #558