### PR TITLE
impl Deref for pgp::crypto::ed25519::SecretKey

### DIFF
--- a/src/crypto/ed25519.rs
+++ b/src/crypto/ed25519.rs
@@ -12,6 +12,8 @@
 //! This implicitly yields differing OpenPGP fingerprints, so the two OpenPGP key variants cannot
 //! be used interchangeably.
 
+use std::ops::Deref;
+
 use rand::{CryptoRng, Rng};
 use signature::{Signer as _, Verifier};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
@@ -67,6 +69,14 @@ impl From<&SecretKey> for EddsaLegacyPublicParams {
         Self::Ed25519 {
             key: value.secret.verifying_key(),
         }
+    }
+}
+
+impl Deref for SecretKey {
+    type Target = ed25519_dalek::SigningKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.secret
     }
 }
 


### PR DESCRIPTION
This diff is analogous to e.g. [RSA](https://github.com/rpgp/rpgp/blob/main/src/crypto/rsa.rs#L73-L79)