### PR TITLE
Adopt RustCrypto new releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,6 @@ jobs:
     - name: doc tests
       run: cargo test --doc
 
-    - name: asm
-      if: ${{ matrix.rust == env.RUST_NIGHTLY }}
-      run: cargo nextest run --lib --bins --tests --all --features asm
-
     - name: malformed-artifact-compat
       if: ${{ matrix.rust == env.RUST_NIGHTLY }}
       run: cargo nextest run --lib --bins --tests --all --features malformed-artifact-compat
@@ -73,9 +69,6 @@ jobs:
 
     - name: tests ignored
       run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release
-
-    - name: asm ignored
-      run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release --features asm
 
     - name: pqc ignored
       run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release --features pqc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae112a25f86ae3598d4e8533ed1e65149cec6eb21918e7a6f4c06dddec370263"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
@@ -781,7 +780,6 @@ dependencies = [
  "elliptic-curve",
  "hash2curve",
  "rand_core 0.10.1",
- "serdect",
  "shake",
  "signature",
  "subtle",
@@ -901,9 +899,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1083,7 +1083,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
- "signature",
  "wnaf",
 ]
 
@@ -1325,7 +1324,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "getrandom 0.4.3",
  "phc",
 ]
 
@@ -1396,6 +1394,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
+ "pkcs8",
  "pretty_assertions",
  "pretty_env_logger",
  "proptest",
@@ -1435,7 +1434,6 @@ checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
  "base64ct",
  "ctutils",
- "getrandom 0.4.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,31 +10,31 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "bytes",
  "crypto-common",
- "generic-array",
+ "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -46,11 +46,12 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
  "aes",
+ "const-oid",
 ]
 
 [[package]]
@@ -76,9 +77,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
 dependencies = [
  "base64ct",
  "blake2",
@@ -95,9 +96,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -154,49 +155,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
 dependencies = [
  "byteorder",
  "cipher",
@@ -240,11 +229,10 @@ dependencies = [
 
 [[package]]
 name = "camellia"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+checksum = "d3ed33f9863ee76491bbe0d7e16a225c694d8525287e320dc7fbe71ee212254c"
 dependencies = [
- "byteorder",
  "cipher",
 ]
 
@@ -256,28 +244,18 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cast5"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+checksum = "1ed80521f830bbce4d3a4857d6f2b91a8339bf0b65711fe189ab6f8d7a2f629e"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfb-mode"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+checksum = "ac64b0984be8510caae81455ea2c8c23e5af6be61c36129df62f3380d5d64e1f"
 dependencies = [
  "cipher",
 ]
@@ -287,6 +265,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -317,10 +307,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
 ]
@@ -352,9 +343,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmac"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+checksum = "ac78aa94ce13e432b332a4d1bf2eff167d3a2520188ee05b337180a42fd2e62e"
 dependencies = [
  "cipher",
  "dbl",
@@ -362,10 +353,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -377,10 +374,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -469,47 +472,73 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "rand_core",
- "typenum",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -524,23 +553,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "cx448"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
-dependencies = [
- "crypto-bigint",
- "elliptic-curve",
- "pkcs8",
- "rand_core",
- "serdect 0.3.0",
- "sha3",
- "signature",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -580,18 +592,18 @@ dependencies = [
 
 [[package]]
 name = "dbl"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+checksum = "f0d7a944e61df464668c5f51f56cc667396a8821434273112948ea0b66e405d7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -652,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
  "cipher",
 ]
@@ -667,25 +679,27 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
 name = "dsa"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+checksum = "5c8573b60d07b5b5cecadc1f978c9b71d5504151e703cbb0439ee4ad301338f3"
 dependencies = [
+ "crypto-bigint",
+ "crypto-common",
+ "crypto-primes",
+ "der",
  "digest",
- "num-bigint-dig",
- "num-traits",
  "pkcs8",
  "rfc6979",
  "sha2",
@@ -695,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+checksum = "885170e03d844ab2850ac8f4e3b01b57dc437718911afbf3e7e17374ba41ef9a"
 dependencies = [
  "aead",
  "cipher",
@@ -708,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
  "digest",
@@ -718,13 +732,14 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -732,17 +747,44 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.10.1",
  "serde",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ed448"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae112a25f86ae3598d4e8533ed1e65149cec6eb21918e7a6f4c06dddec370263"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed448-goldilocks"
+version = "0.14.0-pre.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b805154de2e68f59874ec217ca36790dcffe500cd872c60fe509d28d0814a74d"
+dependencies = [
+ "ed448",
+ "elliptic-curve",
+ "hash2curve",
+ "rand_core 0.10.1",
+ "serdect",
+ "shake",
+ "signature",
+ "subtle",
 ]
 
 [[package]]
@@ -753,26 +795,23 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
- "base64ct",
  "crypto-bigint",
+ "crypto-common",
  "digest",
  "ff",
- "generic-array",
  "group",
  "hkdf",
+ "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.10.1",
  "sec1",
- "serde_json",
- "serdect 0.2.0",
  "subtle",
- "tap",
  "zeroize",
 ]
 
@@ -813,26 +852,19 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "bitvec",
- "rand_core",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "flate2"
@@ -852,54 +884,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -911,12 +923,12 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -928,6 +940,16 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hash2curve"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf40612d7d854743e7189228a6d528f0f6e8502cf6a0cb831d28a218b7f3f6"
+dependencies = [
+ "digest",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -950,24 +972,24 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -980,28 +1002,21 @@ checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.3"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab50e193aebe510fe0e40230145820e02f48dae0cf339ea4204e6e708ff7bd"
-dependencies = [
+ "ctutils",
+ "subtle",
  "typenum",
  "zeroize",
 ]
 
 [[package]]
 name = "idea"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+checksum = "00a418f3a2a1cb2065869bf620a2fab8d8a9d931ce7c06003e1faf0f2e4f0227"
 dependencies = [
  "cipher",
 ]
@@ -1014,11 +1029,11 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1059,35 +1074,37 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
+ "primeorder",
  "sha2",
  "signature",
+ "wnaf",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
+ "cfg-if",
  "cpufeatures",
 ]
 
 [[package]]
 name = "kem"
-version = "0.3.0-pre.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "rand_core",
- "zeroize",
+ "crypto-common",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1095,9 +1112,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libbz2-rs-sys"
@@ -1110,12 +1124,6 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
-
-[[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libz-rs-sys"
@@ -1140,22 +1148,12 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest",
- "md5-asm",
-]
-
-[[package]]
-name = "md5-asm"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19b8ee7fc7d812058d3b708c7f719efd0713d53854648e4223c6fcae709e2df"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1175,30 +1173,45 @@ dependencies = [
 
 [[package]]
 name = "ml-dsa"
-version = "0.0.4"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
 dependencies = [
  "const-oid",
- "hybrid-array 0.3.0",
- "num-traits",
+ "crypto-common",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
  "pkcs8",
- "rand_core",
- "sha3",
+ "shake",
  "signature",
  "zeroize",
 ]
 
 [[package]]
 name = "ml-kem"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97befee0c869cb56f3118f49d0f9bb68c9e3f380dec23c1100aedc4ec3ba239a"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
 dependencies = [
- "hybrid-array 0.2.3",
+ "hybrid-array",
  "kem",
- "rand_core",
- "sha3",
+ "module-lattice",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+ "zeroize",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
  "zeroize",
 ]
 
@@ -1212,50 +1225,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "serde",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1281,14 +1256,14 @@ dependencies = [
 
 [[package]]
 name = "ocb3"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+checksum = "912ff80ac25d578d4c9e260650b9e6d65cea9f5b4a49ce9e88a2c5536e2326b2"
 dependencies = [
  "aead",
  "cipher",
- "ctr",
- "subtle",
+ "ctutils",
+ "dbl",
 ]
 
 [[package]]
@@ -1304,65 +1279,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p521"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "rand_core",
  "sha2",
 ]
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
+ "getrandom 0.4.3",
+ "phc",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1387,12 +1358,13 @@ dependencies = [
  "camellia",
  "cast5",
  "cfb-mode",
+ "chacha20",
  "cipher",
  "const-oid",
  "crc24",
  "criterion",
+ "crypto-bigint",
  "curve25519-dalek",
- "cx448",
  "derive_builder",
  "derive_more",
  "des",
@@ -1401,15 +1373,16 @@ dependencies = [
  "eax",
  "ecdsa",
  "ed25519-dalek",
+ "ed448-goldilocks",
  "elliptic-curve",
  "escape_string",
  "flate2",
- "generic-array",
- "getrandom 0.2.15",
+ "getrandom 0.4.3",
  "glob",
  "hex",
  "hex-literal",
  "hkdf",
+ "hybrid-array",
  "idea",
  "k256",
  "log",
@@ -1418,8 +1391,6 @@ dependencies = [
  "ml-dsa",
  "ml-kem",
  "nom",
- "num-bigint-dig",
- "num-traits",
  "num_enum",
  "ocb3",
  "p256",
@@ -1429,9 +1400,8 @@ dependencies = [
  "pretty_env_logger",
  "proptest",
  "proptest-derive",
- "rand",
- "rand_chacha",
- "rand_xorshift",
+ "rand 0.10.2",
+ "rand_xorshift 0.5.0",
  "rayon",
  "regex",
  "replace_with",
@@ -1442,7 +1412,7 @@ dependencies = [
  "sha1",
  "sha1-checked",
  "sha2",
- "sha3",
+ "sha3 0.12.0",
  "signature",
  "slh-dsa",
  "smallvec",
@@ -1453,25 +1423,36 @@ dependencies = [
  "twofish",
  "web-time",
  "x25519-dalek",
+ "x448",
  "zeroize",
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
+name = "phc"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
  "der",
- "pkcs8",
  "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -1507,13 +1488,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "cpufeatures",
- "opaque-debug",
  "universal-hash",
 ]
 
@@ -1523,7 +1503,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1547,12 +1527,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -1576,9 +1574,9 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "proptest-macro",
- "rand",
+ "rand 0.8.6",
  "rand_chacha",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -1625,15 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1643,7 +1635,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1653,7 +1656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1666,12 +1669,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60aa6af80be32871323012e02e6e65f8a7cc7890931ae421d217ad8fe0df2ccf"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1731,40 +1749,38 @@ checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.9.10"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
  "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.10.1",
  "signature",
  "spki",
- "subtle",
  "zeroize",
 ]
 
@@ -1825,15 +1841,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
- "serdect 0.2.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -1878,19 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
-dependencies = [
- "base16ct",
- "serde",
-]
-
-[[package]]
-name = "serdect"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
@@ -1898,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1909,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "sha1-checked"
-version = "0.10.0"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+checksum = "791ea67ee2842fadd3df7482d5dcd572968573f7c2359adf2328b8d4c271de49"
 dependencies = [
  "digest",
  "sha1",
@@ -1920,68 +1925,74 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "sha2-asm",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest",
  "keccak",
 ]
 
 [[package]]
-name = "shlex"
-version = "2.0.1"
+name = "sha3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "slh-dsa"
-version = "0.0.3"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2f20f4049197e03db1104a6452f4d9e96665d79f880198dce4a7026ba5f267"
+checksum = "371c02fe34044d8866ddf7cb0e8204a87ef31a39f0408bed41c4253ea9dd61ed"
 dependencies = [
  "const-oid",
  "digest",
  "hmac",
- "hybrid-array 0.3.0",
+ "hybrid-array",
  "pkcs8",
- "rand_core",
+ "rand_core 0.10.1",
  "sha2",
- "sha3",
+ "sha3 0.11.0",
  "signature",
  "typenum",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2012,20 +2023,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "strsim"
@@ -2051,19 +2062,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2116,18 +2121,18 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+checksum = "0218ef702a91e18ba84dd516edf8df33a9f9fb4431d6ada13e6f9502c3bcb6fc"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -2155,19 +2160,13 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2193,15 +2192,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2364,32 +2354,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wnaf"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
- "serde",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x448"
+version = "0.14.0-pre.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c166d06b9fa4328c890d46bda797269fb6aeca96393aeaad0e74b4b11550e06"
+dependencies = [
+ "ed448-goldilocks",
  "zeroize",
 ]
 
@@ -2401,32 +2393,11 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.24",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ testresult = "0.4.1"
 chacha20 = { version = "0.10", features = ["rng"] }
 p256 = { version = "0.14" }
 pkcs8 = { version = "0.11", default-features = false, features = ["std", "pem"] }
-rsa = { version = "0.10.0-rc.18", default-features = false, features = ["encoding"] }
+rsa = { version = "0.10.0-rc.18", default-features = false, features = ["encoding", "hazmat"] }
 
 [features]
 default = ["bzip2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,73 +42,66 @@ flate2 = { version = "1.1.1", default-features = false, features = ["zlib-rs"] }
 bzip2 = { version = "0.6.0", optional = true }
 
 # Crypto
-aes = "0.8.4"
-aead = { version = "0.5", features = ["bytes"] }
-argon2 = { version = "0.5", features = ["zeroize", "std"] }
-block-padding = "0.3"
-blowfish = "0.9"
-camellia = "0.1"
-cast5 = "0.11"
-cfb-mode = "0.8.2"
-cipher = "0.4.2"
-const-oid = "0.9.6"
+aes = "0.9"
+aead = { version = "0.6", features = ["bytes"] }
+argon2 = { version = "0.6", features = ["alloc", "zeroize"] }
+block-padding = "0.4.0"
+blowfish = "0.10"
+camellia = "0.2"
+cast5 = "0.12"
+cfb-mode = "0.9"
+cipher = "0.5"
+const-oid = "0.10"
 crc24 = "0.1.6"
-curve25519-dalek = { version = "4.1.3", default-features = false, features = [
+crypto-bigint = { version = "0.7", default-features = false, features = ["alloc"] }
+curve25519-dalek = { version = "5", default-features = false, features = [
     "alloc",
     "precomputed-tables",
     "zeroize",
 ] }
-des = "0.8"
-digest = "0.10.7"
-dsa = "0.6.3"
-ecdsa = "0.16.9"
-ed25519-dalek = { version = "2.1.1", default-features = false, features = ["std", "zeroize", "fast", "rand_core"] }
-elliptic-curve = "0.13"
-generic-array = "0.14.6"
-idea = "0.5"
-md-5 = { version = "0.10.5", features = ["oid"] }
+des = "0.9"
+digest = "0.11"
+dsa = { version = "0.7", features = [ "hazmat" ] }
+ecdsa = "0.17"
+ed25519-dalek = { version = "3", default-features = false, features = ["alloc", "fast", "rand_core", "zeroize"] }
+elliptic-curve = "0.14.1"
+hybrid-array = "0.4.13"
+idea = "0.6.0"
+md-5 = { version = "0.11", features = ["oid"] }
 num_enum = { version = ">=0.5.7, < 0.8", default-features = false }
-num-traits = "0.2.19"
-p256 = { version = "0.13", features = ["ecdsa", "ecdh"] }
-p384 = { version = "0.13", features = ["ecdsa"] }
-p521 = { version = "0.13", features = ["ecdsa", "ecdh"] }
-k256 = { version = "0.13", features = ["ecdsa"] }
-rand = "0.8.6"
-ripemd = { version = "0.1.3", features = ["oid"] }
-rsa = { version = "0.9.10" }
-sha1 = { version = "0.10.6", features = ["oid"] }
-sha1-checked = { version = "0.10", features = ["zeroize"] }
-sha2 = { version = "0.10.6", features = ["oid"] }
-sha3 = { version = "0.10.8", features = ["oid"] }
-signature = "2.2"
+p256 = { version = "0.14", features = ["ecdsa", "ecdh"] }
+p384 = { version = "0.14", features = ["ecdsa"] }
+p521 = { version = "0.14", features = ["ecdsa", "ecdh"] }
+k256 = { version = "0.14", features = ["ecdsa"] }
+rand = "0.10"
+ripemd = { version = "0.2", features = ["oid"] }
+rsa = { version = "0.10.0-rc.18" }
+sha1 = { version = "0.11", features = ["oid"] }
+sha1-checked = { version = "0.11.0-rc.0", features = ["zeroize"] }
+sha2 = { version = "0.11", features = ["oid"] }
+sha3 = { version = "0.12", features = ["oid"] }
+signature = "3"
 subtle = "2.6.1"
-twofish = "0.7"
+twofish = "0.8"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
-getrandom = { version = "0.2", optional = true }
-hkdf = "0.12.4"
-aes-gcm = "0.10.3"
-eax = "0.5.0"
-ocb3 = "0.1"
-aes-kw = { version = "0.2.1", features = ["std"] }
-cx448 = { version = "0.1.1", features = ["zeroize"] }
-num-bigint = { version = "0.8.6", features = [
-    "rand",
-    "i128",
-    "u64_digit",
-    "prime",
-    "zeroize",
-], package = "num-bigint-dig" }
-x25519-dalek = { version = "2.0.1", default-features = false, features = [
-    "alloc",
+getrandom = { version = "0.4", optional = true }
+hkdf = "0.13"
+aes-gcm = "0.11"
+eax = "0.6"
+ocb3 = "0.2"
+aes-kw = { version = "0.3" }
+ed448-goldilocks = { version = "0.14.0-pre.15" }
+x448 = { version = "0.14.0-pre.12", features = ["static_secrets"] }
+x25519-dalek = { version = "3", default-features = false, features = [
     "precomputed-tables",
     "zeroize",
     "static_secrets",
 ] }
 
 # PQC
-ml-kem = { version = "0.2.1", features = ["zeroize", "deterministic"], optional = true }
-ml-dsa = { version = "0.0.4", features = ["zeroize"], optional = true }
-slh-dsa = { version = "0.0.3", optional = true }
+ml-kem = { version = "0.3", features = ["zeroize", "hazmat"], optional = true }
+ml-dsa = { version = "0.1", features = ["zeroize"], optional = true }
+slh-dsa = { version = "0.2.0-rc.5", optional = true }
 replace_with = "0.1.8"
 
 # WASM helpers
@@ -117,11 +110,10 @@ web-time = { version = "1.1", optional = true }
 
 [dev-dependencies]
 glob = "0.3"
-hex-literal = "0.4"
+hex-literal = "1"
 pretty_assertions = "1"
 pretty_env_logger = "0.5"
-rand_chacha = "0.3"
-rand_xorshift = "0.3"
+rand_xorshift = "0.5.0"
 rayon = "1.10"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.47"
@@ -132,14 +124,14 @@ proptest-derive = "0.8.0"
 escape_string = "0.1.2"
 regex = "1.12"
 testresult = "0.4.1"
+chacha20 = { version = "0.10", features = ["rng"] }
 
 [features]
 default = ["bzip2"]
 
 # See README.md for features documentation
 bzip2 = ["dep:bzip2"]
-asm = ["sha2/asm", "md-5/asm"]
-wasm = ["getrandom", "getrandom/js", "web-time"]
+wasm = ["getrandom", "web-time"]
 
 large-rsa = []
 malformed-artifact-compat = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ bzip2 = { version = "0.6.0", optional = true }
 
 # Crypto
 aes = "0.9"
-aead = { version = "0.6", features = ["bytes"] }
-argon2 = { version = "0.6", features = ["alloc", "zeroize"] }
+aead = { version = "0.6", default-features = false, features = ["bytes", "rand_core"] }
+argon2 = { version = "0.6", default-features = false, features = ["alloc", "zeroize"] }
 block-padding = "0.4.0"
 blowfish = "0.10"
 camellia = "0.2"
@@ -62,20 +62,20 @@ curve25519-dalek = { version = "5", default-features = false, features = [
 des = "0.9"
 digest = "0.11"
 dsa = { version = "0.7", features = [ "hazmat" ] }
-ecdsa = "0.17"
+ecdsa = { version =  "0.17", default-features = false }
 ed25519-dalek = { version = "3", default-features = false, features = ["alloc", "fast", "rand_core", "zeroize"] }
-elliptic-curve = "0.14.1"
+elliptic-curve = { version = "0.14.1", default-features = false, features = ["alloc", "sec1"] }
 hybrid-array = "0.4.13"
 idea = "0.6.0"
 md-5 = { version = "0.11", features = ["oid"] }
 num_enum = { version = ">=0.5.7, < 0.8", default-features = false }
-p256 = { version = "0.14", features = ["ecdsa", "ecdh"] }
-p384 = { version = "0.14", features = ["ecdsa"] }
-p521 = { version = "0.14", features = ["ecdsa", "ecdh"] }
-k256 = { version = "0.14", features = ["ecdsa"] }
-rand = "0.10"
+p256 = { version = "0.14", default-features = false, features = ["ecdsa", "ecdh"] }
+p384 = { version = "0.14", default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.14", default-features = false, features = ["ecdsa", "ecdh"] }
+k256 = { version = "0.14", default-features = false, features = ["ecdsa"] }
+rand = { version = "0.10", default-features = false }
 ripemd = { version = "0.2", features = ["oid"] }
-rsa = { version = "0.10.0-rc.18" }
+rsa = { version = "0.10.0-rc.18", default-features = false }
 sha1 = { version = "0.11", features = ["oid"] }
 sha1-checked = { version = "0.11.0-rc.0", features = ["zeroize"] }
 sha2 = { version = "0.11", features = ["oid"] }
@@ -86,12 +86,12 @@ twofish = "0.8"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 getrandom = { version = "0.4", optional = true }
 hkdf = "0.13"
-aes-gcm = "0.11"
-eax = "0.6"
-ocb3 = "0.2"
+aes-gcm = { version = "0.11", default-features = false, features = ["aes"] }
+eax = { version = "0.6", default-features = false }
+ocb3 = { version = "0.2", default-features = false }
 aes-kw = { version = "0.3" }
-ed448-goldilocks = { version = "0.14.0-pre.15" }
-x448 = { version = "0.14.0-pre.12", features = ["static_secrets"] }
+ed448-goldilocks = { version = "0.14.0-pre.15", default-features = false, features = ["signing"] }
+x448 = { version = "0.14.0-pre.12", default-features = false, features = ["static_secrets"] }
 x25519-dalek = { version = "3", default-features = false, features = [
     "precomputed-tables",
     "zeroize",
@@ -114,6 +114,7 @@ hex-literal = "1"
 pretty_assertions = "1"
 pretty_env_logger = "0.5"
 rand_xorshift = "0.5.0"
+rand = "0.10"
 rayon = "1.10"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.47"
@@ -125,13 +126,16 @@ escape_string = "0.1.2"
 regex = "1.12"
 testresult = "0.4.1"
 chacha20 = { version = "0.10", features = ["rng"] }
+p256 = { version = "0.14" }
+pkcs8 = { version = "0.11", default-features = false, features = ["std", "pem"] }
+rsa = { version = "0.10.0-rc.18", default-features = false, features = ["encoding"] }
 
 [features]
 default = ["bzip2"]
 
 # See README.md for features documentation
 bzip2 = ["dep:bzip2"]
-wasm = ["getrandom", "web-time"]
+wasm = ["getrandom/wasm_js", "web-time"]
 
 large-rsa = []
 malformed-artifact-compat = []

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ fn main() -> pgp::errors::Result<()> {
    // Create a signature over DATA with the private key
    let (private_key, _headers) = SignedSecretKey::from_armor_file("key.sec.asc")?;
    let sig = DetachedSignature::sign_binary_data(
-      rand::thread_rng(),
+      &mut rand::rng(),
       &private_key.primary_key, // Sign with the primary (NOTE: This is not always the right key!)
       &Password::empty(),
       HashAlgorithm::Sha256,

--- a/benches/benchmarks/message.rs
+++ b/benches/benchmarks/message.rs
@@ -9,13 +9,13 @@ use pgp::{
     crypto::{ecc_curve::ECCCurve, sym::SymmetricKeyAlgorithm},
     types::{Password, StringToKey},
 };
-use rand::{thread_rng, RngCore};
+use rand::{rng, Rng};
 
 use super::build_key;
 
 fn bench_message(c: &mut Criterion) {
     let mut g = c.benchmark_group("message");
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     g.bench_function("parse_armored_rsa", |b| {
         let message_file_path = "./tests/openpgp-interop/testcases/messages/gnupg-v1-001.asc";
@@ -91,7 +91,7 @@ fn bench_message(c: &mut Criterion) {
             size,
             |b, &size| {
                 let mut bytes = vec![0u8; size];
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 rng.fill_bytes(&mut bytes);
 
                 let s2k = StringToKey::new_default(&mut rng);
@@ -160,7 +160,7 @@ fn bench_message(c: &mut Criterion) {
                 size,
                 |b, &size| {
                     let mut bytes = vec![0u8; size];
-                    let mut rng = rand::thread_rng();
+                    let mut rng = rand::rng();
                     rng.fill_bytes(&mut bytes);
 
                     let signed_key = build_key(kt1.clone(), kt2.clone());
@@ -189,7 +189,7 @@ fn bench_message(c: &mut Criterion) {
                 size,
                 |b, &size| {
                     let mut bytes = vec![0u8; size];
-                    let mut rng = rand::thread_rng();
+                    let mut rng = rand::rng();
                     rng.fill_bytes(&mut bytes);
 
                     let signed_key = build_key(kt1.clone(), kt2.clone());

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -5,7 +5,7 @@ use pgp::{
     crypto::{hash::HashAlgorithm, sym::SymmetricKeyAlgorithm},
     types::CompressionAlgorithm,
 };
-use rand::thread_rng;
+use rand::rng;
 use smallvec::smallvec;
 
 pub mod key;
@@ -46,6 +46,6 @@ pub fn build_key(kt: KeyType, kt_sub: KeyType) -> SignedSecretKey {
         .build()
         .unwrap();
     key_params
-        .generate(thread_rng())
+        .generate(&mut rng())
         .expect("failed to generate secret key, encrypted")
 }

--- a/benches/benchmarks/s2k.rs
+++ b/benches/benchmarks/s2k.rs
@@ -3,11 +3,11 @@ use pgp::{
     crypto::{hash::HashAlgorithm, sym::SymmetricKeyAlgorithm},
     types::StringToKey,
 };
-use rand::distributions::{Alphanumeric, DistString};
+use rand::distr::{Alphanumeric, SampleString};
 
 fn bench_s2k(c: &mut Criterion) {
     let sizes = [10, 100, 1000];
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let mut group = c.benchmark_group("s2k");
     {

--- a/deny.toml
+++ b/deny.toml
@@ -24,5 +24,4 @@ license-files = [
 [advisories]
 ignore = [
     "RUSTSEC-2023-0071", # Waiting for upstream fix
-    "RUSTSEC-2025-0144"  # Waiting for new Rust Crypto releases
 ]

--- a/examples/encrypt_decrypt.rs
+++ b/examples/encrypt_decrypt.rs
@@ -5,7 +5,7 @@ use pgp::{
     crypto::sym::SymmetricKeyAlgorithm,
     types::KeyDetails,
 };
-use rand::thread_rng;
+use rand::rng;
 
 fn main() {
     let encrypted = {
@@ -50,18 +50,20 @@ fn encrypt(cert: &SignedPublicKey, msg: &[u8]) -> Vec<u8> {
         "Unexpected subkey layout"
     );
 
+    let mut rng = rng();
+
     // Initialize encryption of `msg`, configure that the output will be a "SEIPDv1" encryption
     // container.
     let mut builder = MessageBuilder::from_bytes("", msg.to_vec())
-        .seipd_v1(thread_rng(), SymmetricKeyAlgorithm::AES256);
+        .seipd_v1(&mut rng, SymmetricKeyAlgorithm::AES256);
 
     // Add `encryption_subkey` as one recipient of the encrypted message
     builder
-        .encrypt_to_key(thread_rng(), &encryption_subkey)
+        .encrypt_to_key(&mut rng, &encryption_subkey)
         .unwrap();
 
     // Perform the actual encryption of the payload and put together the resulting encrypted message
-    builder.to_vec(thread_rng()).unwrap()
+    builder.to_vec(&mut rng).unwrap()
 }
 
 /// Interpret `msg` as an encrypted message and decrypt it (and optionally decompress one layer of

--- a/examples/generate_key.rs
+++ b/examples/generate_key.rs
@@ -7,7 +7,7 @@ use pgp::{
     ser::Serialize,
     types::KeyDetails,
 };
-use rand::thread_rng;
+use rand::rng;
 
 /// Generate a private example key and the equivalent certificate (aka public key).
 /// Store these two artifacts in `example-key.priv` and `example-key.pub`, respectively.
@@ -90,12 +90,14 @@ fn keygen(
             authkey.build()?,
         ]);
 
+    let mut rng = rng();
+
     // Generate the components of the private key (in particular: the secret key packets)
     let secret_key_params = key_params.build().expect("Build secret_key_params");
 
     // Produce binding self-signatures that link all the components together
     let signed = secret_key_params
-        .generate(thread_rng())
+        .generate(&mut rng)
         .expect("Generate plain key");
 
     Ok(signed)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,9 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 
-rand = "0.8"
+rand = "0.10"
 # for non-deterministic simple PRNG
-rand_chacha = "0.3"
+chacha20 = { version = "0.10", features = ["rng"] }
 # needed for a test case
 buffer-redux = { version = "1.0.0", default-features = false }
 

--- a/fuzz/fuzz_targets/10_signed_secret_key_from_bytes.rs
+++ b/fuzz/fuzz_targets/10_signed_secret_key_from_bytes.rs
@@ -1,12 +1,12 @@
 #![no_main]
 
+use chacha20::ChaCha8Rng;
 use libfuzzer_sys::fuzz_target;
 use pgp::{
     composed::Deserializable,
     types::{EncryptionKey, KeyDetails, Password, SigningKey, VerifyingKey},
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 // build secret key from binary
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/6_message_signing.rs
+++ b/fuzz/fuzz_targets/6_message_signing.rs
@@ -2,6 +2,7 @@
 
 use std::io::Read;
 
+use chacha20::ChaCha8Rng;
 use libfuzzer_sys::fuzz_target;
 use pgp::{
     composed::{ArmorOptions, Deserializable, Message, MessageBuilder, SignedSecretKey},
@@ -9,7 +10,6 @@ use pgp::{
     types::Password,
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 // build message and try decryption with a genuine private key
 fuzz_target!(|data: &[u8]| {
@@ -31,14 +31,14 @@ fuzz_target!(|data: &[u8]| {
             let (decrypt_key, _headers) = SignedSecretKey::from_string(key_input).unwrap();
 
             // fixed seed PRNG for determinism
-            let rng = ChaCha8Rng::seed_from_u64(0);
+            let mut rng = ChaCha8Rng::seed_from_u64(0);
 
             // FUZZER OBSERVATION contrary to initial expectations, signing does not always succeed
             let mut builder = MessageBuilder::from_bytes("", data);
             builder.sign(&*decrypt_key, Password::from("test"), HashAlgorithm::Sha256);
 
             let armored = builder
-                .to_armored_string(rng, ArmorOptions::default())
+                .to_armored_string(&mut rng, ArmorOptions::default())
                 .unwrap();
 
             let signed_message_res = Message::from_armor(armored.as_bytes());

--- a/fuzz/fuzz_targets/9_signed_public_key_from_binary.rs
+++ b/fuzz/fuzz_targets/9_signed_public_key_from_binary.rs
@@ -1,5 +1,6 @@
 #![no_main]
 
+use chacha20::ChaCha8Rng;
 use libfuzzer_sys::fuzz_target;
 use pgp::{
     composed::Deserializable,
@@ -7,7 +8,6 @@ use pgp::{
     types::{EncryptionKey, KeyDetails, SignatureBytes, VerifyingKey},
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 // build public key from binary data
 fuzz_target!(|data: &[u8]| {

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/ijpikb529xsnl811y79vvijm6ifkbgfn-nix-shell

--- a/src/adapter/ecdsa.rs
+++ b/src/adapter/ecdsa.rs
@@ -2,9 +2,8 @@ use std::marker::PhantomData;
 
 use digest::{typenum::Unsigned, OutputSizeUser};
 use ecdsa::{
-    elliptic_curve::{generic_array::ArrayLength, CurveArithmetic},
-    hazmat::DigestPrimitive,
-    PrimeCurve, SignatureSize,
+    elliptic_curve::{array::ArraySize, CurveArithmetic},
+    DigestAlgorithm, EcdsaCurve, PrimeCurve, SignatureSize,
 };
 use signature::{hazmat::PrehashSigner, Keypair};
 
@@ -25,7 +24,7 @@ use crate::{
 impl<C> HPublicKey for ecdsa::VerifyingKey<C>
 where
     Self: PgpEcdsaPublicKey,
-    C: PrimeCurve + CurveArithmetic,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
 {
     const PGP_ALGORITHM: PublicKeyAlgorithm = PublicKeyAlgorithm::ECDSA;
 
@@ -99,8 +98,8 @@ where
 
 impl<C, T> EcdsaSigner<T, C>
 where
-    C: PrimeCurve + DigestPrimitive,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + DigestAlgorithm,
+    SignatureSize<C>: ArraySize,
     T: PrehashSigner<ecdsa::Signature<C>>,
     C::Digest: KnownDigest,
 {
@@ -126,8 +125,8 @@ where
 
 impl<C, T> SigningKey for EcdsaSigner<T, C>
 where
-    C: PrimeCurve + DigestPrimitive,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + DigestAlgorithm,
+    SignatureSize<C>: ArraySize,
     T: PrehashSigner<ecdsa::Signature<C>>,
     C::Digest: KnownDigest,
 {

--- a/src/armor/writer.rs
+++ b/src/armor/writer.rs
@@ -1,8 +1,8 @@
 use std::{hash::Hasher, io::Write};
 
 use base64::engine::{general_purpose, Engine as _};
+use cipher::typenum::U64;
 use crc24::Crc24Hasher;
-use generic_array::typenum::U64;
 
 use super::Headers;
 use crate::{
@@ -153,8 +153,8 @@ mod tests {
 
     use std::io;
 
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
+    use chacha20::ChaCha8Rng;
+    use rand::{RngExt, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
     use super::*;
@@ -185,7 +185,7 @@ mod tests {
         let rng = &mut XorShiftRng::seed_from_u64(0);
 
         for i in 2..1024 {
-            let buf: Vec<u8> = (0..i).map(|_| rng.gen()).collect();
+            let buf: Vec<u8> = (0..i).map(|_| rng.random()).collect();
             let source = TestSource::new(buf);
 
             let mut dest = Vec::new();
@@ -215,7 +215,7 @@ mod tests {
         let mut rng = XorShiftRng::seed_from_u64(0);
 
         for i in 2..1024 {
-            let buf: Vec<u8> = (0..i).map(|_| rng.gen()).collect();
+            let buf: Vec<u8> = (0..i).map(|_| rng.random()).collect();
             let source = TestSource::new(buf);
 
             let mut dest = Vec::new();
@@ -240,7 +240,7 @@ mod tests {
             // Generate data
             let mut buf = vec![0u8; size];
             rng.fill(&mut buf[..]);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             let mut out = Vec::new();
             {

--- a/src/base64/decoder.rs
+++ b/src/base64/decoder.rs
@@ -127,7 +127,7 @@ fn copy_err(err: &io::Error) -> io::Error {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
     use super::*;
@@ -139,13 +139,13 @@ mod tests {
         ]);
 
         for i in 0..n {
-            let data: Vec<u8> = (0..i).map(|_| rng.gen()).collect();
+            let data: Vec<u8> = (0..i).map(|_| rng.random()).collect();
             let mut encoded_data = ENGINE.encode(&data);
 
             if insert_lines {
                 for j in 0..i {
                     // insert line break with a 1/10 chance
-                    if rng.gen_ratio(1, 10) {
+                    if rng.random_ratio(1, 10) {
                         if j >= encoded_data.len() {
                             encoded_data.push('\n');
                         } else {

--- a/src/composed.rs
+++ b/src/composed.rs
@@ -35,10 +35,10 @@
 //!     errors::Result,
 //!     types::Password,
 //! };
-//! use rand::thread_rng;
+//! use rand::rng;
 //! use smallvec::smallvec;
 //!
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //!
 //! // Configure the shape of an OpenPGP Transferable Secret Key that we want to generate
 //! let mut key_params = SecretKeyParamsBuilder::default();

--- a/src/composed/cleartext.rs
+++ b/src/composed/cleartext.rs
@@ -63,9 +63,14 @@ where {
     }
 
     /// Sign the given text.
-    pub fn sign<R>(rng: R, text: &str, key: &impl SigningKey, key_pw: &Password) -> Result<Self>
+    pub fn sign<R>(
+        rng: &mut R,
+        text: &str,
+        key: &impl SigningKey,
+        key_pw: &Password,
+    ) -> Result<Self>
     where
-        R: rand::Rng + rand::CryptoRng,
+        R: rand::CryptoRng + ?Sized,
     {
         let hashed_subpackets = vec![
             Subpacket::regular(SubpacketData::SignatureCreationTime(Timestamp::now()))?,
@@ -411,8 +416,8 @@ fn read_cleartext_body<B: BufRead>(b: &mut B) -> Result<(String, String)> {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::composed::{Any, Deserializable, SignedPublicKey, SignedSecretKey};

--- a/src/composed/key.rs
+++ b/src/composed/key.rs
@@ -14,9 +14,10 @@
 //!     packet::{KeyFlags, UserAttribute, UserId},
 //!     types::{CompressionAlgorithm, Password},
 //! };
-//! use rand::thread_rng;
+//! use rand::rng;
 //! use smallvec::*;
 //!
+//! let mut rng = rng();
 //! let mut key_params = SecretKeyParamsBuilder::default();
 //! key_params
 //!     .key_type(KeyType::Rsa(2048))
@@ -30,7 +31,7 @@
 //!     .build()
 //!     .expect("Must be able to create secret key params");
 //! let signed_secret_key = secret_key_params
-//!     .generate(thread_rng())
+//!     .generate(&mut rng)
 //!     .expect("Failed to generate a plain key.");
 //! let public_key = signed_secret_key.public_key();
 //! ```

--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -1,7 +1,7 @@
 use std::cmp::PartialEq;
 
 use derive_builder::Builder;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use smallvec::SmallVec;
 
 #[cfg(feature = "pqc")]
@@ -269,12 +269,12 @@ impl SecretKeyParamsBuilder {
 }
 
 impl SecretKeyParams {
-    pub fn generate<R: Rng + CryptoRng>(self, mut rng: R) -> Result<SignedSecretKey> {
+    pub fn generate<R: CryptoRng + ?Sized>(self, rng: &mut R) -> Result<SignedSecretKey> {
         let passphrase = self.passphrase;
         let s2k = self
             .s2k
-            .unwrap_or_else(|| S2kParams::new_default(&mut rng, self.version));
-        let (public_params, secret_params) = self.key_type.generate(&mut rng)?;
+            .unwrap_or_else(|| S2kParams::new_default(rng, self.version));
+        let (public_params, secret_params) = self.key_type.generate(rng)?;
         let pub_key = PubKeyInner::new(
             self.version,
             self.key_type.to_alg(),
@@ -335,8 +335,8 @@ impl SecretKeyParams {
                     let passphrase = subkey.passphrase;
                     let s2k = subkey
                         .s2k
-                        .unwrap_or_else(|| S2kParams::new_default(&mut rng, subkey.version));
-                    let (public_params, secret_params) = subkey.key_type.generate(&mut rng)?;
+                        .unwrap_or_else(|| S2kParams::new_default(rng, subkey.version));
+                    let (public_params, secret_params) = subkey.key_type.generate(rng)?;
                     let mut keyflags = KeyFlags::default();
                     keyflags.set_encrypt_comms(subkey.can_encrypt.is_communication());
                     keyflags.set_encrypt_storage(subkey.can_encrypt.is_storage());
@@ -356,7 +356,7 @@ impl SecretKeyParams {
                     // Produce embedded back signature for signing-capable subkeys
                     let embedded = if subkey.can_sign {
                         let backsig =
-                            sub.sign_primary_key_binding(&mut rng, &primary_pub_key, &"".into())?;
+                            sub.sign_primary_key_binding(rng, &primary_pub_key, &"".into())?;
 
                         Some(backsig)
                     } else {
@@ -519,9 +519,9 @@ impl KeyType {
         }
     }
 
-    pub fn generate<R: Rng + CryptoRng>(
+    pub fn generate<R: CryptoRng + ?Sized>(
         &self,
-        rng: R,
+        rng: &mut R,
     ) -> Result<(PublicParams, types::SecretParams)> {
         let (pub_params, plain) = match self {
             KeyType::Rsa(bit_size) => {
@@ -640,8 +640,8 @@ impl KeyType {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
     use smallvec::smallvec;
 
     use super::*;
@@ -675,7 +675,7 @@ mod tests {
         }
     }
 
-    fn gen_rsa_2048<R: Rng + CryptoRng>(mut rng: R, version: KeyVersion) {
+    fn gen_rsa_2048<R: CryptoRng + ?Sized>(rng: &mut R, version: KeyVersion) {
         let mut key_params = SecretKeyParamsBuilder::default();
         key_params
             .version(version)
@@ -715,7 +715,7 @@ mod tests {
             .build()
             .unwrap();
         let signed_key_enc = key_params_enc
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key, encrypted");
 
         let key_params_plain = key_params
@@ -731,7 +731,7 @@ mod tests {
             .build()
             .unwrap();
         let signed_key_plain = key_params_plain
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor_enc = signed_key_enc
@@ -801,7 +801,7 @@ mod tests {
         }
     }
 
-    fn gen_25519_legacy<R: Rng + CryptoRng>(mut rng: R) {
+    fn gen_25519_legacy<R: CryptoRng + ?Sized>(rng: &mut R) {
         // The v4-only key format variants based on Curve 25519 (EdDSALegacy/ECDH over 25519)
 
         let _ = pretty_env_logger::try_init();
@@ -839,7 +839,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -898,7 +898,7 @@ mod tests {
         }
     }
 
-    fn gen_25519_rfc9580<R: Rng + CryptoRng>(mut rng: R, version: KeyVersion) {
+    fn gen_25519_rfc9580<R: CryptoRng + ?Sized>(rng: &mut R, version: KeyVersion) {
         // The RFC 9580 key format variants based on Curve 25519 (X25519/Ed25519)
 
         let _ = pretty_env_logger::try_init();
@@ -938,7 +938,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -969,8 +969,8 @@ mod tests {
         signed_key2.verify_bindings().expect("invalid public key");
     }
 
-    fn gen_ecdsa_ecdh<R: Rng + CryptoRng>(
-        mut rng: R,
+    fn gen_ecdsa_ecdh<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         ecdsa: ECCCurve,
         ecdh: ECCCurve,
         version: KeyVersion,
@@ -1012,7 +1012,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -1120,7 +1120,7 @@ mod tests {
         }
     }
 
-    fn gen_dsa<R: Rng + CryptoRng>(mut rng: R, key_size: DsaKeySize) {
+    fn gen_dsa<R: CryptoRng + ?Sized>(rng: &mut R, key_size: DsaKeySize) {
         let _ = pretty_env_logger::try_init();
 
         let key_params = SecretKeyParamsBuilder::default()
@@ -1156,7 +1156,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -1246,7 +1246,7 @@ mod tests {
         }
     }
 
-    fn gen_448_rfc9580<R: Rng + CryptoRng>(mut rng: R, version: KeyVersion) {
+    fn gen_448_rfc9580<R: CryptoRng + ?Sized>(rng: &mut R, version: KeyVersion) {
         // The RFC 9580 key format variants based on Curve 448 (X448/Ed448)
 
         let _ = pretty_env_logger::try_init();
@@ -1281,7 +1281,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -1626,7 +1626,7 @@ mod tests {
         }
     }
     #[cfg(feature = "pqc")]
-    fn gen_ed25519_ml_kem_x25519<R: Rng + CryptoRng>(mut rng: R, version: KeyVersion) {
+    fn gen_ed25519_ml_kem_x25519<R: CryptoRng + ?Sized>(rng: &mut R, version: KeyVersion) {
         let _ = pretty_env_logger::try_init();
 
         let key_params = SecretKeyParamsBuilder::default()
@@ -1659,7 +1659,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -1705,7 +1705,7 @@ mod tests {
         }
     }
     #[cfg(feature = "pqc")]
-    fn gen_ed448_ml_kem_x448<R: Rng + CryptoRng>(mut rng: R, version: KeyVersion) {
+    fn gen_ed448_ml_kem_x448<R: CryptoRng + ?Sized>(rng: &mut R, version: KeyVersion) {
         let _ = pretty_env_logger::try_init();
 
         let key_params = SecretKeyParamsBuilder::default()
@@ -1738,7 +1738,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key
@@ -1846,8 +1846,8 @@ mod tests {
     }
 
     #[cfg(feature = "pqc")]
-    fn gen_key<R: Rng + CryptoRng>(
-        mut rng: R,
+    fn gen_key<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         version: KeyVersion,
         sign: KeyType,
         sign_hash: HashAlgorithm,
@@ -1881,7 +1881,7 @@ mod tests {
             .unwrap();
 
         let signed_key = key_params
-            .generate(&mut rng)
+            .generate(rng)
             .expect("failed to generate secret key");
 
         let armor = signed_key

--- a/src/composed/message/builder.rs
+++ b/src/composed/message/builder.rs
@@ -5,10 +5,10 @@ use std::{
 };
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use cipher::typenum::U64;
 use crc24::Crc24Hasher;
-use generic_array::typenum::U64;
 use log::debug;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use super::{ArmorOptions, RawSessionKey};
 use crate::{
@@ -110,14 +110,14 @@ pub struct EncryptionSeipdV2 {
 pub trait Encryption: PartialEq {
     fn encrypt<R, READ, W>(
         self,
-        rng: R,
+        rng: &mut R,
         generator: READ,
         partial_chunk_size: u32,
         len: Option<u32>,
         out: W,
     ) -> Result<()>
     where
-        R: Rng + CryptoRng,
+        R: CryptoRng + ?Sized,
         READ: std::io::Read,
         W: std::io::Write;
 
@@ -252,12 +252,12 @@ impl Builder<'_, DummyReader> {
 }
 
 fn prepare<R>(
-    mut rng: R,
+    rng: &mut R,
     typ: SignatureType,
     keys: &[SigningConfig<'_>],
 ) -> Result<Vec<(crate::packet::SignatureConfig, OnePassSignature)>>
 where
-    R: Rng + CryptoRng,
+    R: CryptoRng + ?Sized,
 {
     let mut out = Vec::new();
 
@@ -272,9 +272,7 @@ where
         // prepare signing
         let mut sig_config = match config.key.version() {
             KeyVersion::V4 => crate::packet::SignatureConfig::v4(typ, algorithm, hash_alg),
-            KeyVersion::V6 => {
-                crate::packet::SignatureConfig::v6(&mut rng, typ, algorithm, hash_alg)?
-            }
+            KeyVersion::V6 => crate::packet::SignatureConfig::v6(rng, typ, algorithm, hash_alg)?,
             v => bail!("unsupported key version {:?}", v),
         };
 
@@ -314,13 +312,13 @@ impl<'a, R: Read> Builder<'a, R, NoEncryption> {
     /// Encrypt this message using Seipd V1.
     pub fn seipd_v1<RAND>(
         self,
-        mut rng: RAND,
+        rng: &mut RAND,
         sym_alg: SymmetricKeyAlgorithm,
     ) -> Builder<'a, R, EncryptionSeipdV1>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
     {
-        let session_key = sym_alg.new_session_key(&mut rng);
+        let session_key = sym_alg.new_session_key(rng);
         Builder {
             source: self.source,
             compression: self.compression,
@@ -342,15 +340,15 @@ impl<'a, R: Read> Builder<'a, R, NoEncryption> {
     /// Encrypt this message using Seipd V2.
     pub fn seipd_v2<RAND>(
         self,
-        mut rng: RAND,
+        rng: &mut RAND,
         sym_alg: SymmetricKeyAlgorithm,
         aead: AeadAlgorithm,
         chunk_size: ChunkSize,
     ) -> Builder<'a, R, EncryptionSeipdV2>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
     {
-        let session_key = sym_alg.new_session_key(&mut rng);
+        let session_key = sym_alg.new_session_key(rng);
 
         let mut salt = [0u8; 32];
         rng.fill_bytes(&mut salt);
@@ -427,7 +425,7 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV1> {
     ///
     /// let message = "Hello, world!";
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::rng();
     /// let mut builder = MessageBuilder::from_bytes("", message.as_bytes())
     ///    .seipd_v1(&mut rng, SymmetricKeyAlgorithm::AES256);
     ///
@@ -439,14 +437,14 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV1> {
     /// [PK ESK]: https://www.rfc-editor.org/rfc/rfc9580#name-public-key-encrypted-sessio
     /// # References
     /// [RFC 9580 &sect; 5.1 - Public Key Encrypted Session Key Packet](https://www.rfc-editor.org/rfc/rfc9580#section-5.1)
-    pub fn encrypt_to_key<RAND, E>(&mut self, mut rng: RAND, enc: &E) -> Result<&mut Self>
+    pub fn encrypt_to_key<RAND, E>(&mut self, rng: &mut RAND, enc: &E) -> Result<&mut Self>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
         E: EncryptionKey,
     {
         // Encrypt (asym) the session key using the provided public key.
         let pkes = PublicKeyEncryptedSessionKey::from_session_key_v3(
-            &mut rng,
+            rng,
             &self.encryption.session_key,
             self.encryption.sym_alg,
             enc,
@@ -458,14 +456,18 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV1> {
     /// Encrypt to a public key, but leave the recipient field unset
     ///
     /// See [encrypt_to_key][Self::encrypt_to_key] for more information
-    pub fn encrypt_to_key_anonymous<RAND, E>(&mut self, mut rng: RAND, enc: &E) -> Result<&mut Self>
+    pub fn encrypt_to_key_anonymous<RAND, E>(
+        &mut self,
+        rng: &mut RAND,
+        enc: &E,
+    ) -> Result<&mut Self>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
         E: EncryptionKey,
     {
         // Encrypt (asym) the session key using the provided public key.
         let mut pkes = PublicKeyEncryptedSessionKey::from_session_key_v3(
-            &mut rng,
+            rng,
             &self.encryption.session_key,
             self.encryption.sym_alg,
             enc,
@@ -493,7 +495,7 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV1> {
     /// let message = "Hello, world!";
     /// let password = "password";
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::rng();
     /// let mut msg = MessageBuilder::from_bytes("", message.as_bytes())
     ///     .seipd_v1(&mut rng, SymmetricKeyAlgorithm::AES256);
     ///
@@ -588,7 +590,7 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV2> {
     ///
     /// let message = "Hello, world!";
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::rng();
     /// let mut builder = MessageBuilder::from_bytes("", message.as_bytes()).seipd_v2(
     ///     &mut rng,
     ///     SymmetricKeyAlgorithm::AES256,
@@ -604,14 +606,14 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV2> {
     /// [PK ESK]: https://www.rfc-editor.org/rfc/rfc9580#name-public-key-encrypted-sessio
     /// # References
     /// [RFC 9580 &sect; 5.1 - Public Key Encrypted Session Key Packet](https://www.rfc-editor.org/rfc/rfc9580#section-5.1)
-    pub fn encrypt_to_key<RAND, E>(&mut self, mut rng: RAND, enc: &E) -> Result<&mut Self>
+    pub fn encrypt_to_key<RAND, E>(&mut self, rng: &mut RAND, enc: &E) -> Result<&mut Self>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
         E: EncryptionKey,
     {
         // Encrypt (asym) the session key using the provided public key.
         let pkes = PublicKeyEncryptedSessionKey::from_session_key_v6(
-            &mut rng,
+            rng,
             &self.encryption.session_key,
             enc,
         )?;
@@ -622,14 +624,18 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV2> {
     /// Encrypt to a public key, but leave the recipient field unset
     ///
     /// See [encrypt_to_key][Self::encrypt_to_key] for more information
-    pub fn encrypt_to_key_anonymous<RAND, E>(&mut self, mut rng: RAND, enc: &E) -> Result<&mut Self>
+    pub fn encrypt_to_key_anonymous<RAND, E>(
+        &mut self,
+        rng: &mut RAND,
+        enc: &E,
+    ) -> Result<&mut Self>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
         E: EncryptionKey,
     {
         // Encrypt (asym) the session key using the provided public key.
         let mut pkes = PublicKeyEncryptedSessionKey::from_session_key_v6(
-            &mut rng,
+            rng,
             &self.encryption.session_key,
             enc,
         )?;
@@ -659,7 +665,7 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV2> {
     /// let message = "Hello, world!";
     /// let password = "password";
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::rng();
     /// let mut msg = MessageBuilder::from_bytes("", message.as_bytes()).seipd_v2(
     ///     &mut rng,
     ///     SymmetricKeyAlgorithm::AES256,
@@ -682,16 +688,16 @@ impl<R: Read> Builder<'_, R, EncryptionSeipdV2> {
     /// - [ArmorOptions]
     pub fn encrypt_with_password<RAND>(
         &mut self,
-        mut rng: RAND,
+        rng: &mut RAND,
         s2k: StringToKey,
         msg_pw: &Password,
     ) -> Result<&mut Self>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
     {
         // Encrypt (sym) the session key using the provided password.
         let esk = SymKeyEncryptedSessionKey::encrypt_v6(
-            &mut rng,
+            rng,
             msg_pw,
             &self.encryption.session_key,
             s2k,
@@ -819,9 +825,9 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
     }
 
     /// Write the data out to a writer.
-    pub fn to_writer<RAND, W>(self, rng: RAND, out: W) -> Result<()>
+    pub fn to_writer<RAND, W>(self, rng: &mut RAND, out: W) -> Result<()>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
         W: std::io::Write,
     {
         let sign_typ = self.sign_typ;
@@ -899,12 +905,12 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
     /// Write the data not as binary, but ascii armor encoded.
     pub fn to_armored_writer<RAND, W>(
         self,
-        rng: RAND,
+        rng: &mut RAND,
         opts: ArmorOptions<'_>,
         mut out: W,
     ) -> Result<()>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
         W: std::io::Write,
     {
         let typ = armor::BlockType::Message;
@@ -935,9 +941,9 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
     }
 
     /// Write the data out directly to a file.
-    pub fn to_file<RAND, P>(self, rng: RAND, out_path: P) -> Result<()>
+    pub fn to_file<RAND, P>(self, rng: &mut RAND, out_path: P) -> Result<()>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
         P: AsRef<Path>,
     {
         let out_path: &Path = out_path.as_ref();
@@ -962,12 +968,12 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
     /// Write the data out directly to a file.
     pub fn to_armored_file<RAND, P>(
         self,
-        rng: RAND,
+        rng: &mut RAND,
         out_path: P,
         opts: ArmorOptions<'_>,
     ) -> Result<()>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
         P: AsRef<Path>,
     {
         let out_path: &Path = out_path.as_ref();
@@ -990,9 +996,9 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
     }
 
     /// Write the data out directly to a `Vec<u8>`.
-    pub fn to_vec<RAND>(self, rng: RAND) -> Result<Vec<u8>>
+    pub fn to_vec<RAND>(self, rng: &mut RAND) -> Result<Vec<u8>>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
     {
         let mut out = Vec::new();
         self.to_writer(rng, &mut out)?;
@@ -1000,9 +1006,9 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
     }
 
     /// Write the data as ascii armored data, directly to a `String`.
-    pub fn to_armored_string<RAND>(self, rng: RAND, opts: ArmorOptions<'_>) -> Result<String>
+    pub fn to_armored_string<RAND>(self, rng: &mut RAND, opts: ArmorOptions<'_>) -> Result<String>
     where
-        RAND: Rng + CryptoRng,
+        RAND: CryptoRng + ?Sized,
     {
         let mut out = Vec::new();
         self.to_armored_writer(rng, opts, &mut out)?;
@@ -1013,7 +1019,7 @@ impl<'a, R: Read, E: Encryption> Builder<'a, R, E> {
 
 #[allow(clippy::too_many_arguments)]
 fn to_writer_inner<RAND, R, W, E>(
-    mut rng: RAND,
+    rng: &mut RAND,
     _name: Bytes,
     source: R,
     source_len: Option<u32>,
@@ -1026,7 +1032,7 @@ fn to_writer_inner<RAND, R, W, E>(
     out: W,
 ) -> Result<()>
 where
-    RAND: Rng + CryptoRng,
+    RAND: CryptoRng + ?Sized,
     R: std::io::Read,
     W: std::io::Write,
     E: Encryption,
@@ -1035,7 +1041,7 @@ where
     let literal_data_header = LiteralDataHeader::new(data_mode);
 
     let sign_generator = SignGenerator::new(
-        &mut rng,
+        rng,
         sign_typ,
         literal_data_header,
         partial_chunk_size,
@@ -1050,11 +1056,11 @@ where
             let generator =
                 CompressedDataGenerator::new(compression, sign_generator, len, partial_chunk_size)?;
 
-            encryption.encrypt(&mut rng, generator, partial_chunk_size, None, out)?;
+            encryption.encrypt(rng, generator, partial_chunk_size, None, out)?;
         }
         None => {
             let len = sign_generator.len();
-            encryption.encrypt(&mut rng, sign_generator, partial_chunk_size, len, out)?;
+            encryption.encrypt(rng, sign_generator, partial_chunk_size, len, out)?;
         }
     }
     Ok(())
@@ -1063,14 +1069,14 @@ where
 impl Encryption for NoEncryption {
     fn encrypt<R, READ, W>(
         self,
-        _rng: R,
+        _rng: &mut R,
         mut generator: READ,
         _partial_chunk_size: u32,
         _len: Option<u32>,
         mut out: W,
     ) -> Result<()>
     where
-        R: Rng + CryptoRng,
+        R: CryptoRng + ?Sized,
         READ: std::io::Read,
         W: std::io::Write,
     {
@@ -1086,14 +1092,14 @@ impl Encryption for NoEncryption {
 impl Encryption for EncryptionSeipdV1 {
     fn encrypt<R, READ, W>(
         self,
-        rng: R,
+        rng: &mut R,
         generator: READ,
         partial_chunk_size: u32,
         len: Option<u32>,
         mut out: W,
     ) -> Result<()>
     where
-        R: Rng + CryptoRng,
+        R: CryptoRng + ?Sized,
         READ: std::io::Read,
         W: std::io::Write,
     {
@@ -1136,14 +1142,14 @@ impl Encryption for EncryptionSeipdV1 {
 impl Encryption for EncryptionSeipdV2 {
     fn encrypt<R, READ, W>(
         self,
-        _rng: R,
+        _rng: &mut R,
         generator: READ,
         partial_chunk_size: u32,
         len: Option<u32>,
         mut out: W,
     ) -> Result<()>
     where
-        R: Rng + CryptoRng,
+        R: CryptoRng + ?Sized,
         READ: std::io::Read,
         W: std::io::Write,
     {
@@ -1350,7 +1356,7 @@ impl<R: std::io::Read> std::io::Read for SignatureHashers<R> {
 
 impl<'a, R: std::io::Read> SignGenerator<'a, R> {
     fn new<RAND>(
-        mut rng: RAND,
+        rng: &mut RAND,
         typ: SignatureType,
         literal_data_header: LiteralDataHeader,
         chunk_size: u32,
@@ -1359,9 +1365,9 @@ impl<'a, R: std::io::Read> SignGenerator<'a, R> {
         source_len: Option<u32>,
     ) -> Result<Self>
     where
-        RAND: CryptoRng + Rng,
+        RAND: CryptoRng + ?Sized,
     {
-        let prep = prepare(&mut rng, typ, &signers)?;
+        let prep = prepare(rng, typ, &signers)?;
         let mut configs = VecDeque::with_capacity(prep.len());
         let mut sign_hashers = VecDeque::with_capacity(prep.len());
         let mut ops = VecDeque::with_capacity(prep.len());
@@ -1527,8 +1533,8 @@ impl<R: std::io::Read> std::io::Read for SignGenerator<'_, R> {
 
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha20Rng;
+    use chacha20::ChaCha20Rng;
+    use rand::{RngExt, SeedableRng};
     use testresult::TestResult;
 
     use super::*;
@@ -1606,7 +1612,7 @@ mod tests {
 
             let mut buf = vec![0u8; file_size];
             rng.fill(&mut buf[..]);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             // encrypt it
             let s2k = crate::types::StringToKey::new_iterated(&mut rng, Default::default(), 2);
@@ -1864,7 +1870,7 @@ mod tests {
 
             // Generate data
             let buf = random_string(&mut rng, file_size);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             let mut builder = Builder::from_reader("plaintext.txt", &mut reader);
             builder.sign_text().partial_chunk_size(chunk_size).unwrap();
@@ -1905,7 +1911,7 @@ mod tests {
 
             // Generate data
             let buf = random_string(&mut rng, file_size);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             let mut builder = Builder::from_reader("plaintext.txt", &mut reader);
             builder.sign_text().partial_chunk_size(chunk_size).unwrap();
@@ -1949,7 +1955,7 @@ mod tests {
 
             // Generate data
             let buf = random_string(&mut rng, file_size);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             let mut builder = Builder::from_reader("plaintext.txt", &mut reader);
             builder
@@ -2001,7 +2007,7 @@ mod tests {
 
             // Generate data
             let buf = random_string(&mut rng, file_size);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             println!("data:\n{}", hex::encode(buf.as_bytes()));
 
@@ -2048,7 +2054,7 @@ mod tests {
 
             // Generate data
             let buf = random_string(&mut rng, file_size);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             println!(
                 "data:\n{}\n{} ({})",
@@ -2157,7 +2163,7 @@ mod tests {
 
             // Generate data
             let buf = random_string(&mut rng, file_size);
-            let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+            let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
             let mut builder = Builder::from_reader("plaintext.txt", &mut reader);
             builder
@@ -2242,7 +2248,7 @@ mod tests {
 
                 // Generate data
                 let buf = random_string(&mut rng, file_size);
-                let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+                let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
                 let mut builder = Builder::from_reader("plaintext.txt", &mut reader);
                 builder
@@ -2333,7 +2339,7 @@ mod tests {
 
                 // Generate data
                 let buf = random_string(&mut rng, file_size);
-                let mut reader = ChaosReader::new(rng.clone(), buf.clone());
+                let mut reader = ChaosReader::new(rng.fork(), buf.clone());
 
                 let mut builder = Builder::from_reader("plaintext.txt", &mut reader);
                 builder

--- a/src/composed/message/reader.rs
+++ b/src/composed/message/reader.rs
@@ -20,8 +20,8 @@ pub use self::{
 mod tests {
     use std::io::{BufReader, Read};
 
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
     use testresult::TestResult;
 
     use crate::{
@@ -49,7 +49,7 @@ mod tests {
                     MessageBuilder::from_bytes("test.txt", buf.clone()).to_vec(&mut rng)?
                 };
 
-                let reader = ChaosReader::new(rng.clone(), message.clone());
+                let reader = ChaosReader::new(rng.fork(), message.clone());
                 let mut reader = BufReader::new(reader);
                 let mut msg = Message::from_bytes(&mut reader).unwrap();
 
@@ -91,7 +91,7 @@ mod tests {
                             builder.compression(CompressionAlgorithm::ZIP);
                             builder.to_armored_string(&mut rng, Default::default())?
                         };
-                        let reader = ChaosReader::new(rng.clone(), message.clone());
+                        let reader = ChaosReader::new(rng.fork(), message.clone());
                         let mut reader = BufReader::new(reader);
                         let (message, _) = Message::from_armor(&mut reader)?;
 
@@ -112,7 +112,7 @@ mod tests {
                         }
                         let message = builder.to_vec(&mut rng)?;
 
-                        let reader = ChaosReader::new(rng.clone(), message.clone());
+                        let reader = ChaosReader::new(rng.fork(), message.clone());
                         let mut reader = BufReader::new(reader);
                         let message = Message::from_bytes(&mut reader)?;
 

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -1520,8 +1520,8 @@ impl<'a> From<Option<&'a armor::Headers>> for ArmorOptions<'a> {
 mod tests {
     use std::{fs, io::BufReader};
 
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::{
@@ -1980,7 +1980,7 @@ mod tests {
         .unwrap();
 
         let pkey = skey.public_key();
-        let rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
 
         let mut builder = MessageBuilder::from_bytes("hello.txt", "hello world\n".as_bytes());
         builder
@@ -1988,7 +1988,7 @@ mod tests {
             .sign(&*skey, Password::empty(), HashAlgorithm::Sha256);
 
         let armored = builder
-            .to_armored_string(rng, ArmorOptions::default())
+            .to_armored_string(&mut rng, ArmorOptions::default())
             .expect("serialize");
         // fs::write("./message-string-signed-x25519.asc", &armored).unwrap();
 
@@ -2007,13 +2007,13 @@ mod tests {
         .unwrap();
 
         let pkey = skey.public_key();
-        let rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
 
         let mut builder = MessageBuilder::from_bytes("hello.txt", "hello world\n".as_bytes());
         builder.sign(&*skey, Password::empty(), HashAlgorithm::Sha256);
 
         let armored = builder
-            .to_armored_string(rng, ArmorOptions::default())
+            .to_armored_string(&mut rng, ArmorOptions::default())
             .expect("serialize");
         // fs::write("./message-bytes-signed-x25519.asc", &armored).unwrap();
 
@@ -2033,14 +2033,14 @@ mod tests {
         .unwrap();
 
         let pkey = skey.public_key();
-        let rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
 
         let mut builder = MessageBuilder::from_bytes("hello.txt", "hello world\n".as_bytes());
         builder.sign(&*skey, Password::empty(), HashAlgorithm::Sha256);
         builder.compression(CompressionAlgorithm::ZLIB);
 
         let armored = builder
-            .to_armored_string(rng, ArmorOptions::default())
+            .to_armored_string(&mut rng, ArmorOptions::default())
             .expect("serialize");
         // fs::write("./message-bytes-compressed-signed-x25519.asc", &armored).unwrap();
 
@@ -2106,13 +2106,13 @@ mod tests {
         .unwrap();
         let pkey = skey.public_key();
 
-        let rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
 
         let mut builder = MessageBuilder::from_bytes("hello.txt", "hello world\n".as_bytes());
         builder.sign(&*skey, Password::from("test"), HashAlgorithm::Sha256);
 
         let armored = builder
-            .to_armored_string(rng, ArmorOptions::default())
+            .to_armored_string(&mut rng, ArmorOptions::default())
             .expect("serialize");
 
         // fs::write("./message-string-signed-rsa.asc", &armored).unwrap();
@@ -2135,7 +2135,7 @@ mod tests {
         let pkey = skey.public_key();
 
         for _ in 0..100 {
-            let rng = ChaCha8Rng::seed_from_u64(0);
+            let mut rng = ChaCha8Rng::seed_from_u64(0);
 
             let mut builder = MessageBuilder::from_bytes("hello.txt", "hello world\n".as_bytes());
             builder.compression(CompressionAlgorithm::ZLIB);
@@ -2143,7 +2143,7 @@ mod tests {
             builder.sign(&*skey, Password::from("test"), HashAlgorithm::Sha256);
 
             let armored = builder
-                .to_armored_string(rng, ArmorOptions::default())
+                .to_armored_string(&mut rng, ArmorOptions::default())
                 .expect("serialize");
 
             // fs::write("./message-string-signed-rsa.asc", &armored).unwrap();

--- a/src/composed/signature.rs
+++ b/src/composed/signature.rs
@@ -1,7 +1,6 @@
 use std::{io::Read, iter::Peekable};
 
 use aead::rand_core::CryptoRng;
-use rand::Rng;
 
 use crate::{
     armor,
@@ -30,8 +29,8 @@ impl DetachedSignature {
     }
 
     /// Create a detached data signature over `data`, with [SignatureType::Binary].
-    pub fn sign_binary_data<RNG: Rng + CryptoRng, R: Read>(
-        rng: RNG,
+    pub fn sign_binary_data<RNG: CryptoRng + ?Sized, R: Read>(
+        rng: &mut RNG,
         key: &impl SigningKey,
         key_pw: &Password,
         hash_algorithm: HashAlgorithm,
@@ -52,8 +51,8 @@ impl DetachedSignature {
     /// with explicit subpacket configuration.
     ///
     /// This gives callers full control of the hashed and unhashed subpacket areas.
-    pub fn sign_binary_data_with_subpackets<RNG: Rng + CryptoRng, R: Read>(
-        rng: RNG,
+    pub fn sign_binary_data_with_subpackets<RNG: CryptoRng + ?Sized, R: Read>(
+        rng: &mut RNG,
         key: &impl SigningKey,
         key_pw: &Password,
         hash_algorithm: HashAlgorithm,
@@ -76,8 +75,8 @@ impl DetachedSignature {
     /// Using [SignatureType::Text] makes the signature stable against changes of line ending
     /// encodings. The signature is not invalidated if the plaintext is e.g. changed between using
     /// "LF" line endings or "CR+LF" line endings.
-    pub fn sign_text_data<RNG: Rng + CryptoRng, R: Read>(
-        rng: RNG,
+    pub fn sign_text_data<RNG: CryptoRng + ?Sized, R: Read>(
+        rng: &mut RNG,
         key: &impl SigningKey,
         key_pw: &Password,
         hash_algorithm: HashAlgorithm,
@@ -102,8 +101,8 @@ impl DetachedSignature {
     /// Using [SignatureType::Text] makes the signature stable against changes of line ending
     /// encodings. The signature is not invalidated if the plaintext is e.g. changed between using
     /// "LF" line endings or "CR+LF" line endings.
-    pub fn sign_text_data_with_subpackets<RNG: Rng + CryptoRng, R: Read>(
-        rng: RNG,
+    pub fn sign_text_data_with_subpackets<RNG: CryptoRng + ?Sized, R: Read>(
+        rng: &mut RNG,
         key: &impl SigningKey,
         key_pw: &Password,
         hash_algorithm: HashAlgorithm,
@@ -121,8 +120,8 @@ impl DetachedSignature {
         )
     }
 
-    fn sign_data<RNG: Rng + CryptoRng, R: Read>(
-        rng: RNG,
+    fn sign_data<RNG: CryptoRng + ?Sized, R: Read>(
+        rng: &mut RNG,
         typ: SignatureType,
         key: &impl SigningKey,
         key_pw: &Password,
@@ -231,8 +230,8 @@ fn next<I: Iterator<Item = Result<Packet>>>(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha20Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha20Rng;
 
     use crate::{
         composed::{Deserializable, DetachedSignature, SignedSecretKey, SubpacketConfig},
@@ -246,14 +245,14 @@ mod tests {
 
     #[test]
     fn detached_signature_binary() {
-        let rng = ChaCha20Rng::seed_from_u64(1);
+        let mut rng = ChaCha20Rng::seed_from_u64(1);
 
         let (alice, _) =
             SignedSecretKey::from_armor_file("./tests/autocrypt/alice@autocrypt.example.sec.asc")
                 .unwrap();
 
         let sig = DetachedSignature::sign_binary_data(
-            rng,
+            &mut rng,
             &alice.primary_key,
             &Password::empty(),
             HashAlgorithm::Sha256,
@@ -280,14 +279,14 @@ mod tests {
 
     #[test]
     fn detached_signature_text() {
-        let rng = ChaCha20Rng::seed_from_u64(1);
+        let mut rng = ChaCha20Rng::seed_from_u64(1);
 
         let (alice, _) =
             SignedSecretKey::from_armor_file("./tests/autocrypt/alice@autocrypt.example.sec.asc")
                 .unwrap();
 
         let sig = DetachedSignature::sign_text_data(
-            rng,
+            &mut rng,
             &alice.primary_key,
             &Password::empty(),
             HashAlgorithm::Sha256,
@@ -314,7 +313,7 @@ mod tests {
 
     #[test]
     fn detached_signature_binary_with_subpackets() {
-        let rng = ChaCha20Rng::seed_from_u64(1);
+        let mut rng = ChaCha20Rng::seed_from_u64(1);
 
         let (alice, _) =
             SignedSecretKey::from_armor_file("./tests/autocrypt/alice@autocrypt.example.sec.asc")
@@ -327,7 +326,7 @@ mod tests {
         ];
 
         let sig = DetachedSignature::sign_binary_data_with_subpackets(
-            rng,
+            &mut rng,
             &alice.primary_key,
             &Password::empty(),
             HashAlgorithm::Sha256,
@@ -355,7 +354,7 @@ mod tests {
 
     #[test]
     fn detached_signature_text_with_subpackets() {
-        let rng = ChaCha20Rng::seed_from_u64(1);
+        let mut rng = ChaCha20Rng::seed_from_u64(1);
 
         let (alice, _) =
             SignedSecretKey::from_armor_file("./tests/autocrypt/alice@autocrypt.example.sec.asc")
@@ -368,7 +367,7 @@ mod tests {
         ];
 
         let sig = DetachedSignature::sign_text_data_with_subpackets(
-            rng,
+            &mut rng,
             &alice.primary_key,
             &Password::empty(),
             HashAlgorithm::Sha256,

--- a/src/composed/signed_key.rs
+++ b/src/composed/signed_key.rs
@@ -20,9 +20,10 @@
 //! # use pgp::packet::{self, KeyFlags, UserAttribute, SignatureVersionSpecific, UserId};
 //! # use pgp::crypto::{self, sym::SymmetricKeyAlgorithm, hash::HashAlgorithm, public_key::PublicKeyAlgorithm};
 //! # use pgp::types::{self, VerifyingKey, SigningKey, CompressionAlgorithm, Password};
-//! # use rand::thread_rng;
+//! # use rand::rng;
 //! # use smallvec::*;
 //! #
+//! # let mut rng = rng();
 //! # let mut key_params = SecretKeyParamsBuilder::default();
 //! # key_params
 //! # .key_type(KeyType::Rsa(2048))
@@ -39,7 +40,7 @@
 //! #     CompressionAlgorithm::ZLIB,
 //! # ]);
 //! # let secret_key_params = key_params.build().expect("Must be able to create secret key params");
-//! # let signed_secret_key = secret_key_params.generate(thread_rng()).expect("Failed to generate a plain key.");
+//! # let signed_secret_key = secret_key_params.generate(&mut rng).expect("Failed to generate a plain key.");
 //! # let public_key = signed_secret_key.public_key();
 //! let signing_key = &signed_secret_key.primary_key;
 //! let verification_key = public_key;

--- a/src/composed/signed_key/secret.rs
+++ b/src/composed/signed_key/secret.rs
@@ -1,6 +1,6 @@
 use std::{io, ops::Deref};
 
-use generic_array::GenericArray;
+use hybrid_array::Array;
 use log::warn;
 
 use crate::{
@@ -209,7 +209,7 @@ impl Deref for SignedSecretKey {
 }
 
 impl Imprint for SignedSecretKey {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         self.primary_key.imprint::<D>()
     }
 }
@@ -290,7 +290,7 @@ impl Serialize for SignedSecretSubKey {
 }
 
 impl Imprint for SignedSecretSubKey {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         self.key.imprint::<D>()
     }
 }
@@ -321,8 +321,8 @@ impl From<SignedSecretSubKey> for SignedPublicSubKey {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::{

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -44,6 +44,8 @@ pub enum Error {
     Decrypt { alg: AeadAlgorithm },
     #[snafu(display("encryption failed: {:?}", alg))]
     Encrypt { alg: AeadAlgorithm },
+    #[snafu(display("invalid nonce size"))]
+    InvalidNonce,
 }
 
 /// Available AEAD algorithms.
@@ -116,58 +118,58 @@ impl AeadAlgorithm {
     ) -> Result<(), Error> {
         let res = match (sym_algorithm, self) {
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Gcm) => {
-                let key = GcmKey::<Aes128Gcm>::from_slice(&key[..16]);
-                let cipher = Aes128Gcm::new(key);
-                let nonce = GcmNonce::from_slice(nonce);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = GcmKey::<Aes128Gcm>::try_from(&key[..16]).expect("Invariant violation");
+                let cipher = Aes128Gcm::new(&key);
+                let nonce = GcmNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Gcm) => {
-                let key = GcmKey::<Aes192Gcm>::from_slice(&key[..24]);
-                let cipher = Aes192Gcm::new(key);
-                let nonce = GcmNonce::from_slice(nonce);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = GcmKey::<Aes192Gcm>::try_from(&key[..24]).expect("Invariant violation");
+                let cipher = Aes192Gcm::new(&key);
+                let nonce = GcmNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Gcm) => {
-                let key = GcmKey::<Aes256Gcm>::from_slice(&key[..32]);
-                let cipher = Aes256Gcm::new(key);
-                let nonce = GcmNonce::from_slice(nonce);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = GcmKey::<Aes256Gcm>::try_from(&key[..32]).expect("Invariant violation");
+                let cipher = Aes256Gcm::new(&key);
+                let nonce = GcmNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Eax) => {
-                let key = EaxKey::<Aes128>::from_slice(&key[..16]);
-                let cipher = Eax::<Aes128>::new(key);
-                let nonce = EaxNonce::from_slice(nonce);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = EaxKey::<Aes128>::try_from(&key[..16]).expect("Invariant violation");
+                let cipher = Eax::<Aes128>::new(&key);
+                let nonce = EaxNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Eax) => {
-                let key = EaxKey::<Aes192>::from_slice(&key[..24]);
-                let cipher = Eax::<Aes192>::new(key);
-                let nonce = EaxNonce::from_slice(nonce);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = EaxKey::<Aes192>::try_from(&key[..24]).expect("Invariant violation");
+                let cipher = Eax::<Aes192>::new(&key);
+                let nonce = EaxNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Eax) => {
-                let key = EaxKey::<Aes256>::from_slice(&key[..32]);
-                let cipher = Eax::<Aes256>::new(key);
-                let nonce = EaxNonce::from_slice(nonce);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = EaxKey::<Aes256>::try_from(&key[..32]).expect("Invariant violation");
+                let cipher = Eax::<Aes256>::new(&key);
+                let nonce = EaxNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Ocb) => {
-                let key = Array::from_slice(&key[..16]);
-                let nonce = Ocb3Nonce::from_slice(nonce);
-                let cipher = Aes128Ocb3::new(key);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = Array::try_from(&key[..16]).expect("Invariant violation");
+                let nonce = Ocb3Nonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                let cipher = Aes128Ocb3::new(&key);
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Ocb) => {
-                let key = Array::from_slice(&key[..24]);
-                let nonce = Ocb3Nonce::from_slice(nonce);
-                let cipher = Aes192Ocb3::new(key);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = Array::try_from(&key[..24]).expect("Invariant violation");
+                let nonce = Ocb3Nonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                let cipher = Aes192Ocb3::new(&key);
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Ocb) => {
-                let key = Array::from_slice(&key[..32]);
-                let nonce = Ocb3Nonce::from_slice(nonce);
-                let cipher = Aes256Ocb3::new(key);
-                cipher.decrypt_in_place(nonce, associated_data, buffer)
+                let key = Array::try_from(&key[..32]).expect("Invariant violation");
+                let nonce = Ocb3Nonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                let cipher = Aes256Ocb3::new(&key);
+                cipher.decrypt_in_place(&nonce, associated_data, buffer)
             }
             _ => {
                 return Err(UnsupporedAlgorithmSnafu { alg: *self }.build());
@@ -187,58 +189,58 @@ impl AeadAlgorithm {
     ) -> Result<(), Error> {
         let res = match (sym_algorithm, self) {
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Gcm) => {
-                let key = GcmKey::<Aes128Gcm>::from_slice(&key[..16]);
-                let cipher = Aes128Gcm::new(key);
-                let nonce = GcmNonce::from_slice(nonce);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = GcmKey::<Aes128Gcm>::try_from(&key[..16]).expect("Invariant violation");
+                let cipher = Aes128Gcm::new(&key);
+                let nonce = GcmNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Gcm) => {
-                let key = GcmKey::<Aes192Gcm>::from_slice(&key[..24]);
-                let cipher = Aes192Gcm::new(key);
-                let nonce = GcmNonce::from_slice(nonce);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = GcmKey::<Aes192Gcm>::try_from(&key[..24]).expect("Invariant violation");
+                let cipher = Aes192Gcm::new(&key);
+                let nonce = GcmNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Gcm) => {
-                let key = GcmKey::<Aes256Gcm>::from_slice(&key[..32]);
-                let cipher = Aes256Gcm::new(key);
-                let nonce = GcmNonce::from_slice(nonce);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = GcmKey::<Aes256Gcm>::try_from(&key[..32]).expect("Invariant violation");
+                let cipher = Aes256Gcm::new(&key);
+                let nonce = GcmNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Eax) => {
-                let key = EaxKey::<Aes128>::from_slice(&key[..16]);
-                let cipher = Eax::<Aes128>::new(key);
-                let nonce = EaxNonce::from_slice(nonce);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = EaxKey::<Aes128>::try_from(&key[..16]).expect("Invariant violation");
+                let cipher = Eax::<Aes128>::new(&key);
+                let nonce = EaxNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Eax) => {
-                let key = EaxKey::<Aes192>::from_slice(&key[..24]);
-                let cipher = Eax::<Aes192>::new(key);
-                let nonce = EaxNonce::from_slice(nonce);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = EaxKey::<Aes192>::try_from(&key[..24]).expect("Invariant violation");
+                let cipher = Eax::<Aes192>::new(&key);
+                let nonce = EaxNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Eax) => {
-                let key = EaxKey::<Aes256>::from_slice(&key[..32]);
-                let cipher = Eax::<Aes256>::new(key);
-                let nonce = EaxNonce::from_slice(nonce);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = EaxKey::<Aes256>::try_from(&key[..32]).expect("Invariant violation");
+                let cipher = Eax::<Aes256>::new(&key);
+                let nonce = EaxNonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Ocb) => {
-                let key = Array::from_slice(&key[..16]);
-                let nonce = Ocb3Nonce::from_slice(nonce);
-                let cipher = Aes128Ocb3::new(key);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = Array::try_from(&key[..16]).expect("Invariant violation");
+                let nonce = Ocb3Nonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                let cipher = Aes128Ocb3::new(&key);
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Ocb) => {
-                let key = Array::from_slice(&key[..24]);
-                let nonce = Ocb3Nonce::from_slice(nonce);
-                let cipher = Aes192Ocb3::new(key);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = Array::try_from(&key[..24]).expect("Invariant violation");
+                let nonce = Ocb3Nonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                let cipher = Aes192Ocb3::new(&key);
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Ocb) => {
-                let key = Array::from_slice(&key[..32]);
-                let nonce = Ocb3Nonce::from_slice(nonce);
-                let cipher = Aes256Ocb3::new(key);
-                cipher.encrypt_in_place(nonce, associated_data, buffer)
+                let key = Array::try_from(&key[..32]).expect("Invariant violation");
+                let nonce = Ocb3Nonce::try_from(nonce).map_err(|_| Error::InvalidNonce)?;
+                let cipher = Aes256Ocb3::new(&key);
+                cipher.encrypt_in_place(&nonce, associated_data, buffer)
             }
             _ => {
                 return Err(UnsupporedAlgorithmSnafu { alg: *self }.build());

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -1,14 +1,14 @@
 use aes::{Aes128, Aes192, Aes256};
 use aes_gcm::{
-    aead::{consts::U12, AeadInPlace, KeyInit},
+    aead::{consts::U12, AeadInOut, KeyInit},
     Aes128Gcm, Aes256Gcm, AesGcm, Key as GcmKey, Nonce as GcmNonce,
 };
 use bytes::BytesMut;
-use eax::{Eax, Key as EaxKey, Nonce as EaxNonce};
-use generic_array::{
+use cipher::{
+    array::Array,
     typenum::{U15, U16},
-    GenericArray,
 };
+use eax::{Eax, Key as EaxKey, Nonce as EaxNonce};
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 use ocb3::{Nonce as Ocb3Nonce, Ocb3};
 use sha2::Sha256;
@@ -152,19 +152,19 @@ impl AeadAlgorithm {
                 cipher.decrypt_in_place(nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Ocb) => {
-                let key = GenericArray::from_slice(&key[..16]);
+                let key = Array::from_slice(&key[..16]);
                 let nonce = Ocb3Nonce::from_slice(nonce);
                 let cipher = Aes128Ocb3::new(key);
                 cipher.decrypt_in_place(nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Ocb) => {
-                let key = GenericArray::from_slice(&key[..24]);
+                let key = Array::from_slice(&key[..24]);
                 let nonce = Ocb3Nonce::from_slice(nonce);
                 let cipher = Aes192Ocb3::new(key);
                 cipher.decrypt_in_place(nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Ocb) => {
-                let key = GenericArray::from_slice(&key[..32]);
+                let key = Array::from_slice(&key[..32]);
                 let nonce = Ocb3Nonce::from_slice(nonce);
                 let cipher = Aes256Ocb3::new(key);
                 cipher.decrypt_in_place(nonce, associated_data, buffer)
@@ -223,19 +223,19 @@ impl AeadAlgorithm {
                 cipher.encrypt_in_place(nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES128, AeadAlgorithm::Ocb) => {
-                let key = GenericArray::from_slice(&key[..16]);
+                let key = Array::from_slice(&key[..16]);
                 let nonce = Ocb3Nonce::from_slice(nonce);
                 let cipher = Aes128Ocb3::new(key);
                 cipher.encrypt_in_place(nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES192, AeadAlgorithm::Ocb) => {
-                let key = GenericArray::from_slice(&key[..24]);
+                let key = Array::from_slice(&key[..24]);
                 let nonce = Ocb3Nonce::from_slice(nonce);
                 let cipher = Aes192Ocb3::new(key);
                 cipher.encrypt_in_place(nonce, associated_data, buffer)
             }
             (SymmetricKeyAlgorithm::AES256, AeadAlgorithm::Ocb) => {
-                let key = GenericArray::from_slice(&key[..32]);
+                let key = Array::from_slice(&key[..32]);
                 let nonce = Ocb3Nonce::from_slice(nonce);
                 let cipher = Aes256Ocb3::new(key);
                 cipher.encrypt_in_place(nonce, associated_data, buffer)
@@ -322,9 +322,9 @@ impl ChunkSize {
 mod tests {
     use std::io::Read;
 
+    use chacha20::ChaCha8Rng;
     use log::info;
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
 

--- a/src/crypto/aes_kw.rs
+++ b/src/crypto/aes_kw.rs
@@ -26,18 +26,21 @@ pub fn wrap(key: &[u8], data: &[u8]) -> Result<Vec<u8>, Error> {
     let mut buf = vec![0u8; data.len() + aes_kw::IV_LEN];
     let res = match aes_size {
         128 => {
-            let key = Array::<u8, U16>::from_slice(key);
-            let kek = aes_kw::KwAes128::new(key);
+            let key =
+                Array::<u8, U16>::try_from(key).expect("Invariant violation: key is 16 bytes long");
+            let kek = aes_kw::KwAes128::new(&key);
             kek.wrap_key(data, &mut buf).map(|b| b.to_vec())
         }
         192 => {
-            let key = Array::<u8, U24>::from_slice(key);
-            let kek = aes_kw::KwAes192::new(key);
+            let key =
+                Array::<u8, U24>::try_from(key).expect("Invariant violation: key is 24 bytes long");
+            let kek = aes_kw::KwAes192::new(&key);
             kek.wrap_key(data, &mut buf).map(|b| b.to_vec())
         }
         256 => {
-            let key = Array::<u8, U32>::from_slice(key);
-            let kek = aes_kw::KwAes256::new(key);
+            let key =
+                Array::<u8, U32>::try_from(key).expect("Invariant violation: key is 32 bytes long");
+            let kek = aes_kw::KwAes256::new(&key);
             kek.wrap_key(data, &mut buf).map(|b| b.to_vec())
         }
         _ => {
@@ -54,18 +57,21 @@ pub fn unwrap(key: &[u8], data: &[u8]) -> Result<Zeroizing<Vec<u8>>, Error> {
     let mut buf = Zeroizing::new(vec![0u8; data.len()]);
     let out = match aes_size {
         128 => {
-            let key = Array::<u8, U16>::from_slice(key);
-            let kek = aes_kw::KwAes128::new(key);
+            let key =
+                Array::<u8, U16>::try_from(key).expect("Invariant violation: key is 16 bytes long");
+            let kek = aes_kw::KwAes128::new(&key);
             kek.unwrap_key(data, &mut buf)
         }
         192 => {
-            let key = Array::<u8, U24>::from_slice(key);
-            let kek = aes_kw::KwAes192::new(key);
+            let key =
+                Array::<u8, U24>::try_from(key).expect("Invariant violation: key is 24 bytes long");
+            let kek = aes_kw::KwAes192::new(&key);
             kek.unwrap_key(data, &mut buf)
         }
         256 => {
-            let key = Array::<u8, U32>::from_slice(key);
-            let kek = aes_kw::KwAes256::new(key);
+            let key =
+                Array::<u8, U32>::try_from(key).expect("Invariant violation: key is 32 bytes long");
+            let kek = aes_kw::KwAes256::new(&key);
             kek.unwrap_key(data, &mut buf)
         }
         _ => {

--- a/src/crypto/aes_kw.rs
+++ b/src/crypto/aes_kw.rs
@@ -1,11 +1,10 @@
-use generic_array::{
+use cipher::{
+    array::Array,
     typenum::{U16, U24, U32},
-    GenericArray,
+    KeyInit,
 };
 use snafu::{ResultExt, Snafu};
 use zeroize::Zeroizing;
-
-const IV_LEN: usize = 8;
 
 /// AES key wrap possible errors.
 #[derive(Debug, Snafu)]
@@ -24,21 +23,22 @@ pub enum Error {
 /// As defined in RFC 3394.
 pub fn wrap(key: &[u8], data: &[u8]) -> Result<Vec<u8>, Error> {
     let aes_size = key.len() * 8;
+    let mut buf = vec![0u8; data.len() + aes_kw::IV_LEN];
     let res = match aes_size {
         128 => {
-            let key = GenericArray::<u8, U16>::from_slice(key);
-            let kek = aes_kw::KekAes128::new(key);
-            kek.wrap_vec(data)
+            let key = Array::<u8, U16>::from_slice(key);
+            let kek = aes_kw::KwAes128::new(key);
+            kek.wrap_key(data, &mut buf).map(|b| b.to_vec())
         }
         192 => {
-            let key = GenericArray::<u8, U24>::from_slice(key);
-            let kek = aes_kw::KekAes192::new(key);
-            kek.wrap_vec(data)
+            let key = Array::<u8, U24>::from_slice(key);
+            let kek = aes_kw::KwAes192::new(key);
+            kek.wrap_key(data, &mut buf).map(|b| b.to_vec())
         }
         256 => {
-            let key = GenericArray::<u8, U32>::from_slice(key);
-            let kek = aes_kw::KekAes256::new(key);
-            kek.wrap_vec(data)
+            let key = Array::<u8, U32>::from_slice(key);
+            let kek = aes_kw::KwAes256::new(key);
+            kek.wrap_key(data, &mut buf).map(|b| b.to_vec())
         }
         _ => {
             return Err(InvalidKeySizeSnafu { size: aes_size }.build());
@@ -50,34 +50,29 @@ pub fn wrap(key: &[u8], data: &[u8]) -> Result<Vec<u8>, Error> {
 /// AES Key Unwrap
 /// As defined in RFC 3394.
 pub fn unwrap(key: &[u8], data: &[u8]) -> Result<Zeroizing<Vec<u8>>, Error> {
-    let out_len = data
-        .len()
-        .checked_sub(IV_LEN)
-        .ok_or(Error::InvalidDataSize { size: data.len() })?;
-
-    let mut out = Zeroizing::new(vec![0u8; out_len]);
-
     let aes_size = key.len() * 8;
-    match aes_size {
+    let mut buf = Zeroizing::new(vec![0u8; data.len()]);
+    let out = match aes_size {
         128 => {
-            let key = GenericArray::<u8, U16>::from_slice(key);
-            let kek = aes_kw::KekAes128::new(key);
-            kek.unwrap(data, &mut out)
+            let key = Array::<u8, U16>::from_slice(key);
+            let kek = aes_kw::KwAes128::new(key);
+            kek.unwrap_key(data, &mut buf)
         }
         192 => {
-            let key = GenericArray::<u8, U24>::from_slice(key);
-            let kek = aes_kw::KekAes192::new(key);
-            kek.unwrap(data, &mut out)
+            let key = Array::<u8, U24>::from_slice(key);
+            let kek = aes_kw::KwAes192::new(key);
+            kek.unwrap_key(data, &mut buf)
         }
         256 => {
-            let key = GenericArray::<u8, U32>::from_slice(key);
-            let kek = aes_kw::KekAes256::new(key);
-            kek.unwrap(data, &mut out)
+            let key = Array::<u8, U32>::from_slice(key);
+            let kek = aes_kw::KwAes256::new(key);
+            kek.unwrap_key(data, &mut buf)
         }
         _ => {
             return Err(InvalidKeySizeSnafu { size: aes_size }.build());
         }
     }
+    .map(|b| Zeroizing::new(b.to_vec()))
     .context(WrapSnafu)?;
 
     Ok(out)

--- a/src/crypto/dsa.rs
+++ b/src/crypto/dsa.rs
@@ -1,7 +1,7 @@
+use crypto_bigint::BoxedUint;
 pub use dsa::KeySize;
 use dsa::{Components, Signature, SigningKey};
-use num_bigint::BigUint;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use signature::hazmat::PrehashVerifier;
 use zeroize::Zeroize;
 
@@ -48,9 +48,9 @@ impl Eq for SecretKey {}
 
 impl SecretKey {
     /// Generate a DSA `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R, key_size: KeySize) -> Self {
-        let components = Components::generate(&mut rng, key_size);
-        let signing_key = SigningKey::generate(&mut rng, components);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R, key_size: KeySize) -> Self {
+        let Ok(components) = Components::try_generate_from_rng_with_key_size(rng, key_size);
+        let Ok(signing_key) = SigningKey::try_generate_from_rng_with_components(rng, components);
 
         SecretKey { key: signing_key }
     }
@@ -68,7 +68,7 @@ impl SecretKey {
 
     /// Returns the secret point `x` as big endian bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.key.x().to_bytes_be()
+        self.key.x().to_be_bytes().to_vec()
     }
 }
 
@@ -114,9 +114,9 @@ impl Signer for SecretKey {
 }
 
 /// Verify a DSA signature.
-pub fn verify(params: &DsaPublicParams, hashed: &[u8], r: BigUint, s: BigUint) -> Result<()> {
+pub fn verify(params: &DsaPublicParams, hashed: &[u8], r: BoxedUint, s: BoxedUint) -> Result<()> {
     let verifying_key = &params.key;
-    let signature = Signature::from_components(r, s)?;
+    let signature = Signature::from_components(r, s).ok_or_else(signature::Error::new)?;
     verifying_key.verify_prehash(hashed, &signature)?;
 
     Ok(())
@@ -124,15 +124,14 @@ pub fn verify(params: &DsaPublicParams, hashed: &[u8], r: BigUint, s: BigUint) -
 
 #[cfg(test)]
 mod tests {
-    use num_traits::Num;
     use proptest::prelude::*;
     use rand::SeedableRng;
 
     use super::*;
     use crate::types::Mpi;
 
-    fn hex_num(s: &str) -> BigUint {
-        BigUint::from_str_radix(s, 16).expect("invalid hex")
+    fn hex_num(s: &str) -> BoxedUint {
+        BoxedUint::from_str_radix_vartime(s, 16).expect("invalid hex")
     }
 
     fn hash(hash_algorithm: HashAlgorithm, text: &str) -> Vec<u8> {
@@ -175,22 +174,25 @@ mod tests {
             DsaPublicParams::try_from_mpi(Mpi::from(p), Mpi::from(q), Mpi::from(g), Mpi::from(y))
                 .unwrap();
 
-        let check =
-            |hash_algorithm: HashAlgorithm, text: &str, _k: BigUint, r: BigUint, s: BigUint| {
-                let hashed = hash(hash_algorithm, text);
-                let key = dsa::SigningKey::from_components(params.key.clone(), x.clone()).unwrap();
-                let key = SecretKey { key };
+        let check = |hash_algorithm: HashAlgorithm,
+                     text: &str,
+                     _k: BoxedUint,
+                     r: BoxedUint,
+                     s: BoxedUint| {
+            let hashed = hash(hash_algorithm, text);
+            let key = dsa::SigningKey::from_components(params.key.clone(), x.clone()).unwrap();
+            let key = SecretKey { key };
 
-                let SignatureBytes::Mpis(res) =
-                    key.sign(hash_algorithm, &hashed).expect("failed to sign")
-                else {
-                    panic!("invalid sig format");
-                };
-                let new_r = res[0].clone();
-                let new_s = res[1].clone();
-                assert_eq!((new_r, new_s), (r.clone().into(), s.clone().into()));
-                verify(&params, &hashed, r, s).expect("failed to verify");
+            let SignatureBytes::Mpis(res) =
+                key.sign(hash_algorithm, &hashed).expect("failed to sign")
+            else {
+                panic!("invalid sig format");
             };
+            let new_r = res[0].clone();
+            let new_s = res[1].clone();
+            assert_eq!((new_r, new_s), (r.clone().into(), s.clone().into()));
+            verify(&params, &hashed, r, s).expect("failed to verify");
+        };
 
         check(
             HashAlgorithm::Sha1,
@@ -310,22 +312,25 @@ mod tests {
             DsaPublicParams::try_from_mpi(Mpi::from(p), Mpi::from(q), Mpi::from(g), Mpi::from(y))
                 .unwrap();
 
-        let check =
-            |hash_algorithm: HashAlgorithm, text: &str, _k: BigUint, r: BigUint, s: BigUint| {
-                let hashed = hash(hash_algorithm, text);
-                let key = dsa::SigningKey::from_components(params.key.clone(), x.clone()).unwrap();
-                let key = SecretKey { key };
+        let check = |hash_algorithm: HashAlgorithm,
+                     text: &str,
+                     _k: BoxedUint,
+                     r: BoxedUint,
+                     s: BoxedUint| {
+            let hashed = hash(hash_algorithm, text);
+            let key = dsa::SigningKey::from_components(params.key.clone(), x.clone()).unwrap();
+            let key = SecretKey { key };
 
-                let SignatureBytes::Mpis(res) =
-                    key.sign(hash_algorithm, &hashed).expect("failed to sign")
-                else {
-                    panic!("invalid sig format");
-                };
-                let new_r = res[0].clone();
-                let new_s = res[1].clone();
-                assert_eq!((new_r, new_s), (r.clone().into(), s.clone().into()));
-                verify(&params, &hashed, r, s).expect("failed to verify");
+            let SignatureBytes::Mpis(res) =
+                key.sign(hash_algorithm, &hashed).expect("failed to sign")
+            else {
+                panic!("invalid sig format");
             };
+            let new_r = res[0].clone();
+            let new_s = res[1].clone();
+            assert_eq!((new_r, new_s), (r.clone().into(), s.clone().into()));
+            verify(&params, &hashed, r, s).expect("failed to verify");
+        };
 
         check(
             HashAlgorithm::Sha1,
@@ -401,10 +406,11 @@ mod tests {
 
     prop_compose! {
         pub fn key_gen()(seed: u64) -> dsa::SigningKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
             #[allow(deprecated)]
-            let components = Components::generate(&mut rng, KeySize::DSA_1024_160);
-            SigningKey::generate(&mut rng, components)
+            let Ok(components) = Components::try_generate_from_rng_with_key_size(&mut rng, KeySize::DSA_1024_160);
+            let Ok(out) = SigningKey::try_generate_from_rng_with_components(&mut rng, components);
+            out
         }
     }
 }

--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -1,6 +1,8 @@
 use bytes::BytesMut;
+use cipher::array::Array;
+use elliptic_curve::Generate;
 use log::debug;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
@@ -40,7 +42,7 @@ impl PartialEq for Curve25519Legacy {
 impl Eq for Curve25519Legacy {}
 
 impl Curve25519Legacy {
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let mut secret_key_bytes =
             Zeroizing::new([0u8; ECCCurve::Curve25519Legacy.secret_key_length()]);
         rng.fill_bytes(&mut *secret_key_bytes);
@@ -158,22 +160,22 @@ impl TryFrom<&SecretKey> for EcdhPublicParams {
 
 impl SecretKey {
     /// Generate an ECDH KeyPair.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R, curve: &ECCCurve) -> Result<Self> {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R, curve: &ECCCurve) -> Result<Self> {
         match curve {
             ECCCurve::Curve25519Legacy => {
                 let key = Curve25519Legacy::generate(rng);
                 Ok(Self::Curve25519Legacy(key))
             }
             ECCCurve::P256 => {
-                let secret = p256::SecretKey::random(&mut rng);
+                let secret = p256::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::P256 { secret })
             }
             ECCCurve::P384 => {
-                let secret = p384::SecretKey::random(&mut rng);
+                let secret = p384::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::P384 { secret })
             }
             ECCCurve::P521 => {
-                let secret = p521::SecretKey::random(&mut rng);
+                let secret = p521::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::P521 { secret })
             }
             _ => unsupported_err!("curve {:?} for ECDH", curve),
@@ -203,10 +205,7 @@ impl SecretKey {
             EcdhPublicParams::P521 { .. } => {
                 const SIZE: usize = ECCCurve::P521.secret_key_length();
                 let raw = pad_key::<SIZE>(d.as_ref())?;
-                let arr =
-                    generic_array::GenericArray::<u8, generic_array::typenum::U66>::from_slice(
-                        &raw[..],
-                    );
+                let arr = Array::<u8, cipher::typenum::U66>::from_slice(&raw[..]);
                 let secret = elliptic_curve::SecretKey::<p521::NistP521>::from_bytes(arr)?;
 
                 Ok(SecretKey::P521 { secret })
@@ -423,7 +422,7 @@ where
     C: elliptic_curve::CurveArithmetic,
     elliptic_curve::FieldBytesSize<C>: elliptic_curve::sec1::ModulusSize,
     elliptic_curve::AffinePoint<C>:
-        elliptic_curve::sec1::FromEncodedPoint<C> + elliptic_curve::sec1::ToEncodedPoint<C>,
+        elliptic_curve::sec1::FromSec1Point<C> + elliptic_curve::sec1::ToSec1Point<C>,
 {
     ensure_eq!(public_point.len(), pub_bytes, "invalid public point");
 
@@ -582,8 +581,8 @@ fn pad(plain: &[u8]) -> Vec<u8> {
 }
 
 /// ECDH encryption.
-pub fn encrypt<R: CryptoRng + Rng>(
-    mut rng: R,
+pub fn encrypt<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     params: &EcdhPublicParams,
     fingerprint: &[u8],
     plain: &[u8],
@@ -679,24 +678,24 @@ pub fn encrypt<R: CryptoRng + Rng>(
 
 /// Derive a shared secret in encryption, for a Rust Crypto curve.
 /// Returns a pair of `(our_public key, shared_secret)`.
-fn derive_shared_secret_encryption<C, R: CryptoRng + Rng>(
-    mut rng: R,
+fn derive_shared_secret_encryption<C, R: CryptoRng + ?Sized>(
+    rng: &mut R,
     their_public: &elliptic_curve::PublicKey<C>,
 ) -> Result<(Vec<u8>, Vec<u8>)>
 where
     C: elliptic_curve::CurveArithmetic + elliptic_curve::point::PointCompression,
     elliptic_curve::FieldBytesSize<C>: elliptic_curve::sec1::ModulusSize,
     elliptic_curve::AffinePoint<C>:
-        elliptic_curve::sec1::FromEncodedPoint<C> + elliptic_curve::sec1::ToEncodedPoint<C>,
+        elliptic_curve::sec1::FromSec1Point<C> + elliptic_curve::sec1::ToSec1Point<C>,
 {
-    let our_secret = elliptic_curve::ecdh::EphemeralSecret::<C>::random(&mut rng);
+    let our_secret = elliptic_curve::ecdh::EphemeralSecret::<C>::generate_from_rng(rng);
 
     // derive shared secret
     let shared_secret = our_secret.diffie_hellman(their_public);
 
     // encode our public key
     let our_public = elliptic_curve::PublicKey::<C>::from(&our_secret);
-    let our_public = elliptic_curve::sec1::EncodedPoint::<C>::from(our_public);
+    let our_public = elliptic_curve::sec1::Sec1Point::<C>::from(our_public);
 
     Ok((
         our_public.as_bytes().to_vec(),
@@ -708,9 +707,10 @@ where
 mod tests {
     use std::fs;
 
+    use chacha20::ChaCha20Rng;
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
-    use rand::{RngCore, SeedableRng};
-    use rand_chacha::ChaChaRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::{
@@ -727,7 +727,7 @@ mod tests {
             ECCCurve::P384,
             ECCCurve::P521,
         ] {
-            let mut rng = ChaChaRng::from_seed([0u8; 32]);
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
             let skey = SecretKey::generate(&mut rng, &curve).unwrap();
             let pub_params: EcdhPublicParams = (&skey).try_into().unwrap();
@@ -903,29 +903,29 @@ mod tests {
 
     prop_compose! {
         pub fn key_p256_gen()(seed: u64) -> p256::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-             p256::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+             p256::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
     prop_compose! {
         pub fn key_p384_gen()(seed: u64) -> p384::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p384::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p384::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
     prop_compose! {
         pub fn key_p521_gen()(seed: u64) -> p521::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p521::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p521::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
     prop_compose! {
         pub fn key_k256_gen()(seed: u64) -> k256::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            k256::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            k256::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
@@ -936,7 +936,7 @@ mod tests {
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             any::<u64>()
                 .prop_map(|seed| {
-                    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                    let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
                     Curve25519Legacy::generate(&mut rng)
                 })
                 .boxed()

--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -205,8 +205,8 @@ impl SecretKey {
             EcdhPublicParams::P521 { .. } => {
                 const SIZE: usize = ECCCurve::P521.secret_key_length();
                 let raw = pad_key::<SIZE>(d.as_ref())?;
-                let arr = Array::<u8, cipher::typenum::U66>::from_slice(&raw[..]);
-                let secret = elliptic_curve::SecretKey::<p521::NistP521>::from_bytes(arr)?;
+                let arr = Array::<u8, cipher::typenum::U66>::from(raw);
+                let secret = elliptic_curve::SecretKey::<p521::NistP521>::from_bytes(&arr)?;
 
                 Ok(SecretKey::P521 { secret })
             }

--- a/src/crypto/ecdsa.rs
+++ b/src/crypto/ecdsa.rs
@@ -1,7 +1,8 @@
 use bytes::BytesMut;
 use ecdsa::SigningKey;
+use elliptic_curve::Generate;
 use p521::NistP521;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use signature::hazmat::{PrehashSigner, PrehashVerifier};
 use zeroize::ZeroizeOnDrop;
 
@@ -72,22 +73,22 @@ impl TryFrom<&SecretKey> for EcdsaPublicParams {
 
 impl SecretKey {
     /// Generate an ECDSA `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R, curve: &ECCCurve) -> Result<Self> {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R, curve: &ECCCurve) -> Result<Self> {
         match curve {
             ECCCurve::P256 => {
-                let secret = p256::SecretKey::random(&mut rng);
+                let secret = p256::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::P256(secret))
             }
             ECCCurve::P384 => {
-                let secret = p384::SecretKey::random(&mut rng);
+                let secret = p384::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::P384(secret))
             }
             ECCCurve::P521 => {
-                let secret = p521::SecretKey::random(&mut rng);
+                let secret = p521::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::P521(secret))
             }
             ECCCurve::Secp256k1 => {
-                let secret = k256::SecretKey::random(&mut rng);
+                let secret = k256::SecretKey::generate_from_rng(rng);
                 Ok(SecretKey::Secp256k1(secret))
             }
             _ => unsupported_err!("curve {:?} for ECDSA", curve),
@@ -366,34 +367,35 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
     use rand::SeedableRng;
 
     prop_compose! {
         pub fn key_p256_gen()(seed: u64) -> p256::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-             p256::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+             p256::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
     prop_compose! {
         pub fn key_p384_gen()(seed: u64) -> p384::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p384::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p384::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
     prop_compose! {
         pub fn key_p521_gen()(seed: u64) -> p521::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p521::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p521::SecretKey::generate_from_rng(&mut rng)
         }
     }
 
     prop_compose! {
         pub fn key_k256_gen()(seed: u64) -> k256::SecretKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            k256::SecretKey::random(&mut rng)
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            k256::SecretKey::generate_from_rng(&mut rng)
         }
     }
 }

--- a/src/crypto/ed25519.rs
+++ b/src/crypto/ed25519.rs
@@ -14,7 +14,7 @@
 
 use std::ops::Deref;
 
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use signature::{Signer as _, Verifier};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
@@ -89,7 +89,7 @@ impl SecretKey {
     ///
     /// This SecretKey type can be used to form either a `EddsaLegacyPublicParams` or a
     /// `Ed25519PublicParams`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R, mode: Mode) -> Self {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R, mode: Mode) -> Self {
         let mut bytes = Zeroizing::new([0u8; ed25519_dalek::SECRET_KEY_LENGTH]);
         rng.fill_bytes(&mut *bytes);
         let secret = ed25519_dalek::SigningKey::from_bytes(&bytes);

--- a/src/crypto/ed448.rs
+++ b/src/crypto/ed448.rs
@@ -41,9 +41,8 @@ impl SecretKey {
     }
 
     pub fn try_from_bytes(raw: [u8; KEY_LEN]) -> Result<Self> {
-        let secret = ed448_goldilocks::SigningKey::from(
-            *ed448_goldilocks::EdwardsScalarBytes::from_slice(&raw),
-        );
+        let secret =
+            ed448_goldilocks::SigningKey::from(ed448_goldilocks::EdwardsScalarBytes::from(raw));
         Ok(Self { secret })
     }
 
@@ -117,8 +116,8 @@ mod tests {
     use proptest::prelude::*;
 
     prop_compose! {
-        pub fn key_gen()(bytes: [u8; 57]) -> ed448_goldilocks::SigningKey {
-            ed448_goldilocks::SigningKey::from(ed448_goldilocks::EdwardsScalarBytes::from_slice(&bytes))
+         pub fn key_gen()(bytes: [u8; 57]) -> ed448_goldilocks::SigningKey {
+            ed448_goldilocks::SigningKey::from(ed448_goldilocks::EdwardsScalarBytes::try_from(&bytes[..]).expect("invariant violation"))
         }
     }
 }

--- a/src/crypto/ml_dsa65_ed25519.rs
+++ b/src/crypto/ml_dsa65_ed25519.rs
@@ -1,6 +1,6 @@
-use ml_dsa::{KeyGen, MlDsa65};
-use rand::{CryptoRng, Rng};
-use signature::{Signer as _, Verifier};
+use ml_dsa::MlDsa65;
+use rand::CryptoRng;
+use signature::{Keypair, Signer as _, Verifier};
 use zeroize::ZeroizeOnDrop;
 
 use crate::{
@@ -44,16 +44,16 @@ impl From<&SecretKey> for MlDsa65Ed25519PublicParams {
 
 impl SecretKey {
     /// Generate an Ed448 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let ed25519 = ed25519_dalek::SigningKey::generate(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let ed25519 = ed25519_dalek::SigningKey::generate(rng);
         let mut ml_dsa_seed = [0u8; ML_DSA65_KEY_LEN];
         rng.fill_bytes(&mut ml_dsa_seed);
-        let ml_dsa = MlDsa65::key_gen_internal(&ml_dsa_seed.into());
+        let ml_dsa = ml_dsa::SigningKey::<MlDsa65>::from_seed(&ml_dsa_seed.into());
 
         SecretKey {
             ed25519,
-            ml_dsa_sign: Box::new(ml_dsa.signing_key().clone()),
-            ml_dsa_verify: Box::new(ml_dsa.verifying_key().clone()),
+            ml_dsa_verify: Box::new(ml_dsa.verifying_key()),
+            ml_dsa_sign: Box::new(ml_dsa),
             ml_dsa_seed,
         }
     }
@@ -62,12 +62,12 @@ impl SecretKey {
     pub fn try_from_bytes(ed25519: [u8; 32], ml_dsa: [u8; 32]) -> Result<Self> {
         let ed25519 = ed25519_dalek::SigningKey::from_bytes(&ed25519);
         // use the seed format
-        let keypair = MlDsa65::key_gen_internal(&ml_dsa.into());
+        let keypair = ml_dsa::SigningKey::<MlDsa65>::from_seed(&ml_dsa.into());
 
         Ok(Self {
             ed25519,
-            ml_dsa_sign: Box::new(keypair.signing_key().clone()),
-            ml_dsa_verify: Box::new(keypair.verifying_key().clone()),
+            ml_dsa_verify: Box::new(keypair.verifying_key()),
+            ml_dsa_sign: Box::new(keypair),
             ml_dsa_seed: ml_dsa,
         })
     }
@@ -144,9 +144,9 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 

--- a/src/crypto/ml_dsa87_ed448.rs
+++ b/src/crypto/ml_dsa87_ed448.rs
@@ -1,6 +1,7 @@
-use ml_dsa::{KeyGen, MlDsa87};
-use rand::{CryptoRng, Rng};
-use signature::{Signer as _, Verifier};
+use elliptic_curve::Generate;
+use ml_dsa::MlDsa87;
+use rand::CryptoRng;
+use signature::{Keypair, Signer as _, Verifier};
 use zeroize::ZeroizeOnDrop;
 
 use crate::{
@@ -20,7 +21,7 @@ pub const ML_DSA87_KEY_LEN: usize = 32;
 pub struct SecretKey {
     /// The secret point.
     #[debug("..")]
-    ed448: cx448::SigningKey,
+    ed448: ed448_goldilocks::SigningKey,
     #[debug("..")]
     ml_dsa_sign: Box<ml_dsa::SigningKey<MlDsa87>>,
     #[debug("{}", hex::encode(ml_dsa_verify.encode()))]
@@ -45,16 +46,16 @@ impl From<&SecretKey> for MlDsa87Ed448PublicParams {
 
 impl SecretKey {
     /// Generate an Ed448 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let ed448 = cx448::SigningKey::generate(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let ed448 = ed448_goldilocks::SigningKey::generate_from_rng(rng);
         let mut ml_dsa_seed = [0u8; ML_DSA87_KEY_LEN];
         rng.fill_bytes(&mut ml_dsa_seed);
-        let ml_dsa = MlDsa87::key_gen_internal(&ml_dsa_seed.into());
+        let ml_dsa = ml_dsa::SigningKey::<MlDsa87>::from_seed(&ml_dsa_seed.into());
 
         SecretKey {
             ed448,
-            ml_dsa_sign: Box::new(ml_dsa.signing_key().clone()),
-            ml_dsa_verify: Box::new(ml_dsa.verifying_key().clone()),
+            ml_dsa_verify: Box::new(ml_dsa.verifying_key()),
+            ml_dsa_sign: Box::new(ml_dsa),
             ml_dsa_seed,
         }
     }
@@ -64,14 +65,15 @@ impl SecretKey {
         ed448: [u8; ED448_KEY_LEN],
         ml_dsa: [u8; ML_DSA87_KEY_LEN],
     ) -> Result<Self> {
-        let ed448 = cx448::SigningKey::from(cx448::SecretKey::from_slice(&ed448));
+        let ed448 =
+            ed448_goldilocks::SigningKey::from(ed448_goldilocks::SecretKey::from_slice(&ed448));
         // use the seed format
-        let keypair = MlDsa87::key_gen_internal(&ml_dsa.into());
+        let keypair = ml_dsa::SigningKey::<MlDsa87>::from_seed(&ml_dsa.into());
 
         Ok(Self {
             ed448,
-            ml_dsa_sign: Box::new(keypair.signing_key().clone()),
-            ml_dsa_verify: Box::new(keypair.verifying_key().clone()),
+            ml_dsa_verify: Box::new(keypair.verifying_key()),
+            ml_dsa_sign: Box::new(keypair),
             ml_dsa_seed: ml_dsa,
         })
     }
@@ -120,7 +122,7 @@ impl Signer for SecretKey {
 
 /// Verify an EdDSA signature.
 pub fn verify(
-    ed_key: &cx448::VerifyingKey,
+    ed_key: &ed448_goldilocks::VerifyingKey,
     ml_dsa_key: &ml_dsa::VerifyingKey<MlDsa87>,
     hash: HashAlgorithm,
     hashed: &[u8],
@@ -137,7 +139,7 @@ pub fn verify(
     );
     ensure_eq!(sig_bytes.len(), 114 + 4627, "invalid signature length");
 
-    let ed_sig = cx448::Signature::try_from(&sig_bytes[..114])?;
+    let ed_sig = ed448_goldilocks::Signature::try_from(&sig_bytes[..114])?;
     ed_key.verify(hashed, &ed_sig)?;
 
     let ml_sig = sig_bytes[114..].try_into()?;
@@ -148,9 +150,9 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 

--- a/src/crypto/ml_dsa87_ed448.rs
+++ b/src/crypto/ml_dsa87_ed448.rs
@@ -65,8 +65,9 @@ impl SecretKey {
         ed448: [u8; ED448_KEY_LEN],
         ml_dsa: [u8; ML_DSA87_KEY_LEN],
     ) -> Result<Self> {
-        let ed448 =
-            ed448_goldilocks::SigningKey::from(ed448_goldilocks::SecretKey::from_slice(&ed448));
+        let ed448 = ed448_goldilocks::SigningKey::from(
+            ed448_goldilocks::SecretKey::try_from(&ed448[..]).expect("invariant violation"),
+        );
         // use the seed format
         let keypair = ml_dsa::SigningKey::<MlDsa87>::from_seed(&ml_dsa.into());
 

--- a/src/crypto/ml_kem1024_x448.rs
+++ b/src/crypto/ml_kem1024_x448.rs
@@ -1,13 +1,13 @@
 use std::cmp::PartialEq;
 
-use cx448::x448::{PublicKey, Secret};
 use log::debug;
 use ml_kem::{
     kem::{Decapsulate, DecapsulationKey, Encapsulate, EncapsulationKey},
-    KemCore, MlKem1024, MlKem1024Params,
+    FromSeed, MlKem1024,
 };
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use sha3::{Digest, Sha3_256};
+use x448::{PublicKey, StaticSecret};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use crate::{
@@ -26,12 +26,12 @@ pub const ML_KEM1024_KEY_LEN: usize = 64;
 #[derive(Clone, derive_more::Debug)]
 pub struct SecretKey {
     #[debug("..")]
-    x448: Secret,
+    x448: StaticSecret,
     #[debug("..")]
-    ml_kem: Box<DecapsulationKey<MlKem1024Params>>,
+    ml_kem: Box<DecapsulationKey<MlKem1024>>,
     /// Seed `d` and `z`
     #[debug("..")]
-    ml_kem_seed: (Zeroizing<[u8; 32]>, Zeroizing<[u8; 32]>),
+    ml_kem_seed: Zeroizing<ml_kem::Seed>,
 }
 
 impl ZeroizeOnDrop for SecretKey {}
@@ -55,10 +55,9 @@ impl Eq for SecretKey {}
 
 impl Serialize for SecretKey {
     fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
-        let (a, b, c) = self.as_bytes();
+        let (a, b) = self.as_bytes();
         writer.write_all(a)?;
         writer.write_all(b)?;
-        writer.write_all(c)?;
         Ok(())
     }
 
@@ -69,21 +68,19 @@ impl Serialize for SecretKey {
 
 impl SecretKey {
     /// Generate a `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let x448 = Secret::new(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let x448 = StaticSecret::random_from_rng(rng);
 
-        let mut d = Zeroizing::new([0u8; 32]);
-        let mut z = Zeroizing::new([0u8; 32]);
+        let mut seed = ml_kem::Seed::default();
 
-        rng.fill_bytes(&mut *d);
-        rng.fill_bytes(&mut *z);
+        rng.fill_bytes(&mut seed);
 
-        let (de, _) = MlKem1024::generate_deterministic(&((*d).into()), &((*z).into()));
+        let (de, _) = MlKem1024::from_seed(&seed);
 
         Self {
             x448,
             ml_kem: Box::new(de),
-            ml_kem_seed: (d, z),
+            ml_kem_seed: Zeroizing::new(seed),
         }
     }
 
@@ -92,27 +89,22 @@ impl SecretKey {
         x448: [u8; X448_KEY_LEN],
         ml_kem: [u8; ML_KEM1024_KEY_LEN],
     ) -> Result<Self> {
-        let d: Zeroizing<[u8; 32]> = Zeroizing::new(ml_kem[..32].try_into().expect("fixed size"));
-        let z: Zeroizing<[u8; 32]> = Zeroizing::new(ml_kem[32..].try_into().expect("fixed size"));
+        let seed = ml_kem::Seed::from(ml_kem);
 
-        let (ml_kem, _) = MlKem1024::generate_deterministic(&((*d).into()), &((*z).into()));
+        let (ml_kem, _) = MlKem1024::from_seed(&seed);
 
-        let x = Secret::from(x448);
+        let x = StaticSecret::from(x448);
 
         Ok(Self {
             x448: x,
             ml_kem: Box::new(ml_kem),
-            ml_kem_seed: (d, z),
+            ml_kem_seed: Zeroizing::new(seed),
         })
     }
 
     /// Returns the individual secret keys in their raw byte level representation.
-    pub fn as_bytes(&self) -> (&[u8; X448_KEY_LEN], &[u8; 32], &[u8; 32]) {
-        (
-            self.x448.as_bytes(),
-            &self.ml_kem_seed.0,
-            &self.ml_kem_seed.1,
-        )
+    pub fn as_bytes(&self) -> (&[u8; X448_KEY_LEN], &[u8; ML_KEM1024_KEY_LEN]) {
+        (self.x448.as_bytes(), self.ml_kem_seed.as_ref())
     }
 }
 
@@ -124,7 +116,7 @@ pub struct EncryptionFields<'a> {
 
     /// Recipient public key
     pub ecdh_pub_key: &'a PublicKey,
-    pub ml_kem_pub_key: &'a EncapsulationKey<MlKem1024Params>,
+    pub ml_kem_pub_key: &'a EncapsulationKey<MlKem1024>,
 
     /// Encrypted and wrapped session key
     pub encrypted_session_key: &'a [u8],
@@ -164,24 +156,20 @@ impl Decryptor for SecretKey {
 /// <https://www.rfc-editor.org/info/rfc9980/#name-x448-kem>
 fn x448_kem_decaps(
     their_public: &PublicKey,
-    ecdh_secret_key: &Secret,
+    ecdh_secret_key: &StaticSecret,
     _ecdh_public_key: &PublicKey,
 ) -> [u8; 56] {
     // derive shared secret
-    let shared_secret = ecdh_secret_key
-        .as_diffie_hellman(their_public)
-        .expect("point checked before");
+    let shared_secret = ecdh_secret_key.diffie_hellman(their_public);
 
     *shared_secret.as_bytes()
 }
 
 fn ml_kem_1024_decaps(
     ml_kem_ciphertext: &[u8; 1568],
-    ml_kem_secret_key: &DecapsulationKey<MlKem1024Params>,
+    ml_kem_secret_key: &DecapsulationKey<MlKem1024>,
 ) -> [u8; 32] {
-    let shared = ml_kem_secret_key
-        .decapsulate(ml_kem_ciphertext.into())
-        .expect("infallible");
+    let shared = ml_kem_secret_key.decapsulate(ml_kem_ciphertext.into());
     shared.into()
 }
 
@@ -220,10 +208,10 @@ fn multi_key_combine(
 /// - ecdh_ciphertext
 /// - ml_kem_ciphertext
 /// - encrypted data
-pub fn encrypt<R: CryptoRng + Rng>(
-    mut rng: R,
+pub fn encrypt<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     ecdh_public_key: &PublicKey,
-    ml_kem_public_key: &EncapsulationKey<MlKem1024Params>,
+    ml_kem_public_key: &EncapsulationKey<MlKem1024>,
     plain: &[u8],
 ) -> Result<(PublicKey, Box<[u8; 1568]>, Vec<u8>)> {
     // Maximum length for `plain` - FIXME: what should the maximum be, here?
@@ -235,9 +223,9 @@ pub fn encrypt<R: CryptoRng + Rng>(
     );
 
     // Compute (ecdhCipherText, ecdhKeyShare) := ECDH-KEM.Encaps(ecdhPublicKey)
-    let (ecdh_ciphertext, ecdh_key_share) = x448_kem_encaps(&mut rng, ecdh_public_key);
+    let (ecdh_ciphertext, ecdh_key_share) = x448_kem_encaps(rng, ecdh_public_key);
     // Compute (mlkemCipherText, mlkemKeyShare) := ML-KEM.Encaps(mlkemPublicKey)
-    let (ml_kem_ciphertext, ml_kem_key_share) = ml_kem_encaps(&mut rng, ml_kem_public_key);
+    let (ml_kem_ciphertext, ml_kem_key_share) = ml_kem_encaps(rng, ml_kem_public_key);
     // Compute KEK := multiKeyCombine(mlkemKeyShare, mlkemCipherText, mlkemPublicKey, ecdhKeyShare,
     //                        ecdhCipherText, ecdhPublicKey, algId, 256)
 
@@ -256,39 +244,39 @@ pub fn encrypt<R: CryptoRng + Rng>(
 }
 
 /// <https://www.rfc-editor.org/info/rfc9980/#name-x448-kem>
-fn x448_kem_encaps<R: CryptoRng + Rng>(
-    mut rng: R,
+fn x448_kem_encaps<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     public_key: &PublicKey,
 ) -> (PublicKey, [u8; 56]) {
     // Generate an ephemeral key pair {v, V} via V = X448(v,U(P)) where v is a randomly generated octet string with a length of 56 octets
-    let our_secret = Secret::new(&mut rng);
+    let our_secret = StaticSecret::random_from_rng(rng);
 
     // Compute the shared coordinate X = X448(v, R) where R is the recipient's public key ecdhPublicKey
-    let shared_secret = our_secret.as_diffie_hellman(public_key).expect("checked");
+    let shared_secret = our_secret.diffie_hellman(public_key);
 
     let ephemeral_public = PublicKey::from(&our_secret);
     (ephemeral_public, *shared_secret.as_bytes())
 }
 
-fn ml_kem_encaps<R: CryptoRng + Rng>(
-    mut rng: R,
-    public_key: &EncapsulationKey<MlKem1024Params>,
+fn ml_kem_encaps<R: CryptoRng + ?Sized>(
+    rng: &mut R,
+    public_key: &EncapsulationKey<MlKem1024>,
 ) -> (Box<[u8; 1568]>, [u8; 32]) {
-    let (ciphertext, share) = public_key.encapsulate(&mut rng).expect("infallible");
+    let (ciphertext, share) = public_key.encapsulate_with_rng(rng);
     (Box::new(ciphertext.into()), share.into())
 }
 
 #[cfg(test)]
 mod tests {
+    use chacha20::{ChaCha20Rng, ChaCha8Rng};
     use proptest::prelude::*;
-    use rand::{RngCore, SeedableRng};
-    use rand_chacha::{ChaCha8Rng, ChaChaRng};
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
     #[test]
     fn test_encrypt_decrypt() {
-        let mut rng = ChaChaRng::seed_from_u64(0);
+        let mut rng = ChaCha20Rng::seed_from_u64(0);
         let skey = SecretKey::generate(&mut rng);
         let pub_params: MlKem1024X448PublicParams = (&skey).into();
 

--- a/src/crypto/ml_kem768_x25519.rs
+++ b/src/crypto/ml_kem768_x25519.rs
@@ -3,9 +3,9 @@ use std::cmp::PartialEq;
 use log::debug;
 use ml_kem::{
     kem::{Decapsulate, DecapsulationKey, Encapsulate, EncapsulationKey},
-    KemCore, MlKem768, MlKem768Params,
+    FromSeed, MlKem768,
 };
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use sha3::{Digest, Sha3_256};
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
@@ -28,10 +28,10 @@ pub struct SecretKey {
     #[debug("..")]
     x25519: StaticSecret,
     #[debug("..")]
-    ml_kem: Box<DecapsulationKey<MlKem768Params>>,
+    ml_kem: Box<DecapsulationKey<MlKem768>>,
     /// Seed `d` and `z`
     #[debug("..")]
-    ml_kem_seed: (Zeroizing<[u8; 32]>, Zeroizing<[u8; 32]>),
+    ml_kem_seed: Zeroizing<ml_kem::Seed>,
 }
 impl ZeroizeOnDrop for SecretKey {}
 
@@ -55,11 +55,10 @@ impl Eq for SecretKey {}
 
 impl Serialize for SecretKey {
     fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
-        let (a, b, c) = self.as_bytes();
+        let (a, b) = self.as_bytes();
 
         writer.write_all(a)?;
         writer.write_all(b)?;
-        writer.write_all(c)?;
         Ok(())
     }
 
@@ -70,22 +69,20 @@ impl Serialize for SecretKey {
 
 impl SecretKey {
     /// Generate a `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let mut secret_key_bytes = Zeroizing::new([0u8; 32]);
         rng.fill_bytes(&mut *secret_key_bytes);
         let x25519 = StaticSecret::from(*secret_key_bytes);
 
-        let mut d = Zeroizing::new([0u8; 32]);
-        let mut z = Zeroizing::new([0u8; 32]);
+        let mut seed = ml_kem::Seed::default();
 
-        rng.fill_bytes(&mut *d);
-        rng.fill_bytes(&mut *z);
+        rng.fill_bytes(&mut seed);
 
-        let (de, _) = MlKem768::generate_deterministic(&((*d).into()), &((*z).into()));
+        let (de, _) = MlKem768::from_seed(&seed);
         Self {
             x25519,
             ml_kem: Box::new(de),
-            ml_kem_seed: (d, z),
+            ml_kem_seed: Zeroizing::new(seed),
         }
     }
 
@@ -94,27 +91,22 @@ impl SecretKey {
         x25519: [u8; X25519_KEY_LEN],
         ml_kem: [u8; ML_KEM768_KEY_LEN],
     ) -> Result<Self> {
-        let d: Zeroizing<[u8; 32]> = Zeroizing::new(ml_kem[..32].try_into().expect("fixed size"));
-        let z: Zeroizing<[u8; 32]> = Zeroizing::new(ml_kem[32..].try_into().expect("fixed size"));
+        let seed = ml_kem::Seed::from(ml_kem);
 
-        let (ml_kem, _) = MlKem768::generate_deterministic(&((*d).into()), &((*z).into()));
+        let (ml_kem, _) = MlKem768::from_seed(&seed);
 
         let x = x25519_dalek::StaticSecret::from(x25519);
 
         Ok(Self {
             x25519: x,
             ml_kem: Box::new(ml_kem),
-            ml_kem_seed: (d, z),
+            ml_kem_seed: Zeroizing::new(seed),
         })
     }
 
     /// Returns the individual secret keys in their raw byte level representation.
-    pub fn as_bytes(&self) -> (&[u8; X25519_KEY_LEN], &[u8; 32], &[u8; 32]) {
-        (
-            self.x25519.as_bytes(),
-            &self.ml_kem_seed.0,
-            &self.ml_kem_seed.1,
-        )
+    pub fn as_bytes(&self) -> (&[u8; X25519_KEY_LEN], &[u8; ML_KEM768_KEY_LEN]) {
+        (self.x25519.as_bytes(), self.ml_kem_seed.as_ref())
     }
 }
 
@@ -126,7 +118,7 @@ pub struct EncryptionFields<'a> {
 
     /// Recipient public key (32 bytes)
     pub ecdh_pub_key: &'a x25519_dalek::PublicKey,
-    pub ml_kem_pub_key: &'a EncapsulationKey<MlKem768Params>,
+    pub ml_kem_pub_key: &'a EncapsulationKey<MlKem768>,
 
     /// Encrypted and wrapped session key
     pub encrypted_session_key: &'a [u8],
@@ -181,11 +173,9 @@ fn x25519_kem_decaps(
 
 fn ml_kem_768_decaps(
     ml_kem_ciphertext: &[u8; 1088],
-    ml_kem_secret_key: &DecapsulationKey<MlKem768Params>,
+    ml_kem_secret_key: &DecapsulationKey<MlKem768>,
 ) -> [u8; 32] {
-    let shared = ml_kem_secret_key
-        .decapsulate(ml_kem_ciphertext.into())
-        .expect("infallible");
+    let shared = ml_kem_secret_key.decapsulate(ml_kem_ciphertext.into());
     shared.into()
 }
 
@@ -224,10 +214,10 @@ fn multi_key_combine(
 /// - ecdh_ciphertext
 /// - ml_kem_ciphertext
 /// - encrypted data
-pub fn encrypt<R: CryptoRng + Rng>(
-    mut rng: R,
+pub fn encrypt<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     ecdh_public_key: &x25519_dalek::PublicKey,
-    ml_kem_public_key: &EncapsulationKey<MlKem768Params>,
+    ml_kem_public_key: &EncapsulationKey<MlKem768>,
     plain: &[u8],
 ) -> Result<([u8; 32], Box<[u8; 1088]>, Vec<u8>)> {
     // Maximum length for `plain` - FIXME: what should the maximum be, here?
@@ -239,9 +229,9 @@ pub fn encrypt<R: CryptoRng + Rng>(
     );
 
     // Compute (ecdhCipherText, ecdhKeyShare) := ECDH-KEM.Encaps(ecdhPublicKey)
-    let (ecdh_ciphertext, ecdh_key_share) = x25519_kem_encaps(&mut rng, ecdh_public_key);
+    let (ecdh_ciphertext, ecdh_key_share) = x25519_kem_encaps(rng, ecdh_public_key);
     // Compute (mlkemCipherText, mlkemKeyShare) := ML-KEM.Encaps(mlkemPublicKey)
-    let (ml_kem_ciphertext, ml_kem_key_share) = ml_kem_encaps(&mut rng, ml_kem_public_key);
+    let (ml_kem_ciphertext, ml_kem_key_share) = ml_kem_encaps(rng, ml_kem_public_key);
     // Compute KEK := multiKeyCombine(mlkemKeyShare, mlkemCipherText, mlkemPublicKey, ecdhKeyShare,
     //                        ecdhCipherText, ecdhPublicKey, algId, 256)
 
@@ -260,8 +250,8 @@ pub fn encrypt<R: CryptoRng + Rng>(
 }
 
 /// <https://www.rfc-editor.org/info/rfc9980/#name-x25519-kem>
-fn x25519_kem_encaps<R: CryptoRng + Rng>(
-    mut rng: R,
+fn x25519_kem_encaps<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     public_key: &x25519_dalek::PublicKey,
 ) -> ([u8; 32], [u8; 32]) {
     // Generate an ephemeral key pair {v, V} via V = X25519(v,U(P)) where v is a randomly generated octet string with a length of 32 octets
@@ -276,25 +266,25 @@ fn x25519_kem_encaps<R: CryptoRng + Rng>(
     (ephemeral_public.to_bytes(), shared_secret.to_bytes())
 }
 
-fn ml_kem_encaps<R: CryptoRng + Rng>(
-    mut rng: R,
-    public_key: &EncapsulationKey<MlKem768Params>,
+fn ml_kem_encaps<R: CryptoRng + ?Sized>(
+    rng: &mut R,
+    public_key: &EncapsulationKey<MlKem768>,
 ) -> (Box<[u8; 1088]>, [u8; 32]) {
-    let (ciphertext, share) = public_key.encapsulate(&mut rng).expect("infallible");
+    let (ciphertext, share) = public_key.encapsulate_with_rng(rng);
     (Box::new(ciphertext.into()), share.into())
 }
 
 #[cfg(test)]
 mod tests {
+    use chacha20::{ChaCha20Rng, ChaCha8Rng};
     use proptest::prelude::*;
-    use rand::{RngCore, SeedableRng};
-    use rand_chacha::{ChaCha8Rng, ChaChaRng};
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
     #[test]
     fn test_encrypt_decrypt() {
-        let mut rng = ChaChaRng::seed_from_u64(0);
+        let mut rng = ChaCha20Rng::seed_from_u64(0);
         let skey = SecretKey::generate(&mut rng);
         let pub_params: MlKem768X25519PublicParams = (&skey).into();
 

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -248,7 +248,7 @@ mod tests {
     prop_compose! {
         pub fn key_gen()(seed: u64) -> RsaPrivateKey {
             let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
-            RsaPrivateKey::new(&mut rng, 512).unwrap()
+            RsaPrivateKey::new_unchecked(&mut rng, 512).unwrap()
         }
     }
 }

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -1,7 +1,7 @@
+use crypto_bigint::NonZero;
 use digest::{const_oid::AssociatedOid, Digest};
 use md5::Md5;
-use num_bigint::ModInverse;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use ripemd::Ripemd160;
 use rsa::{
     pkcs1v15::{Pkcs1v15Encrypt, Signature as RsaSignature, SigningKey, VerifyingKey},
@@ -46,13 +46,13 @@ impl SecretKey {
     /// Generate an RSA `SecretKey`.
     ///
     /// Errors on unsupported `bit_size`s.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R, bit_size: usize) -> Result<Self> {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         if bit_size > MAX_KEY_SIZE_GENERATE {
             log::warn!("rejecting SecretKey::generate for RSA key size: {bit_size}");
             return Err(Error::InvalidKeyLength);
         }
 
-        let key = RsaPrivateKey::new(&mut rng, bit_size)?;
+        let key = RsaPrivateKey::new(rng, bit_size)?;
 
         Ok(SecretKey(key))
     }
@@ -64,8 +64,9 @@ impl SecretKey {
         q: Mpi,
         _u: Mpi,
     ) -> Result<Self> {
+        let n = pub_params.key.n().clone().get();
         let secret_key = RsaPrivateKey::from_components(
-            pub_params.key.n().clone(),
+            n,
             pub_params.key.e().clone(),
             d.into(),
             vec![p.into(), q.into()],
@@ -77,13 +78,8 @@ impl SecretKey {
     fn to_mpi(&self) -> (Mpi, Mpi, Mpi, Mpi) {
         let d = self.0.d();
         let p = &self.0.primes()[0];
-        let q = &self.0.primes()[1];
-        let u = p
-            .clone()
-            .mod_inverse(q)
-            .expect("invalid prime")
-            .to_biguint()
-            .expect("invalid prime");
+        let q = &NonZero::new(self.0.primes()[1].clone()).expect("Invariant violation");
+        let u = p.clone().invert_mod(q).expect("invalid prime");
 
         (Mpi::from(d), Mpi::from(p), Mpi::from(q), Mpi::from(u))
     }
@@ -95,18 +91,16 @@ impl SecretKey {
 
     /// Returns `d`, `p`, `q`, `u` in big endian
     pub fn to_bytes(&self) -> (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
-        let d = self.0.d().to_bytes_be();
-        let p = self.0.primes()[0].to_bytes_be();
-        let q = self.0.primes()[1].to_bytes_be();
-        let u = self.0.primes()[0]
-            .clone()
-            .mod_inverse(&self.0.primes()[1])
-            .expect("invalid prime")
-            .to_biguint()
-            .expect("invalid prime")
-            .to_bytes_be();
+        let d = self.0.d().to_be_bytes();
+        let p = &self.0.primes()[0];
+        let q = &NonZero::new(self.0.primes()[1].clone()).expect("Invariant violation");
+        let u = p.clone().invert_mod(q).expect("invalid prime");
 
-        (d, p, q, u)
+        let p = p.to_be_bytes();
+        let q = q.to_be_bytes();
+        let u = u.to_be_bytes();
+
+        (d.to_vec(), p.to_vec(), q.to_vec(), u.to_vec())
     }
 }
 
@@ -180,12 +174,12 @@ impl From<RsaPrivateKey> for SecretKey {
 }
 
 /// RSA encryption using PKCS1v15 padding.
-pub fn encrypt<R: CryptoRng + Rng>(
-    mut rng: R,
+pub fn encrypt<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     key: &RsaPublicKey,
     plaintext: &[u8],
 ) -> Result<PkeskBytes> {
-    let data = key.encrypt(&mut rng, Pkcs1v15Encrypt, plaintext)?;
+    let data = key.encrypt(rng, Pkcs1v15Encrypt, plaintext)?;
 
     Ok(PkeskBytes::Rsa {
         mpi: Mpi::from_slice(&data[..]),
@@ -253,7 +247,7 @@ mod tests {
 
     prop_compose! {
         pub fn key_gen()(seed: u64) -> RsaPrivateKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
             RsaPrivateKey::new(&mut rng, 512).unwrap()
         }
     }

--- a/src/crypto/slh_dsa_shake128f.rs
+++ b/src/crypto/slh_dsa_shake128f.rs
@@ -1,4 +1,4 @@
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use signature::{Signer as _, Verifier};
 use slh_dsa::Shake128f;
 use zeroize::ZeroizeOnDrop;
@@ -41,8 +41,8 @@ impl From<&SecretKey> for SlhDsaShake128fPublicParams {
 
 impl SecretKey {
     /// Generate an Ed448 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let key = slh_dsa::SigningKey::new(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let key = slh_dsa::SigningKey::new(rng);
 
         SecretKey { key }
     }
@@ -117,9 +117,9 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 

--- a/src/crypto/slh_dsa_shake128s.rs
+++ b/src/crypto/slh_dsa_shake128s.rs
@@ -1,4 +1,4 @@
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use signature::{Signer as _, Verifier};
 use slh_dsa::Shake128s;
 use zeroize::ZeroizeOnDrop;
@@ -41,8 +41,8 @@ impl From<&SecretKey> for SlhDsaShake128sPublicParams {
 
 impl SecretKey {
     /// Generate an Ed448 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let key = slh_dsa::SigningKey::new(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let key = slh_dsa::SigningKey::new(rng);
 
         SecretKey { key }
     }
@@ -117,9 +117,9 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 

--- a/src/crypto/slh_dsa_shake256s.rs
+++ b/src/crypto/slh_dsa_shake256s.rs
@@ -1,4 +1,4 @@
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use signature::{Signer as _, Verifier};
 use slh_dsa::Shake256s;
 use zeroize::ZeroizeOnDrop;
@@ -41,8 +41,8 @@ impl From<&SecretKey> for SlhDsaShake256sPublicParams {
 
 impl SecretKey {
     /// Generate an Ed448 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let key = slh_dsa::SigningKey::new(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let key = slh_dsa::SigningKey::new(rng);
 
         SecretKey { key }
     }
@@ -117,9 +117,9 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 

--- a/src/crypto/sym.rs
+++ b/src/crypto/sym.rs
@@ -2,16 +2,13 @@ use aes::{Aes128, Aes192, Aes256};
 use blowfish::Blowfish;
 use camellia::{Camellia128, Camellia192, Camellia256};
 use cast5::Cast5;
-use cfb_mode::{
-    cipher::{AsyncStreamCipher, KeyIvInit},
-    BufEncryptor, Decryptor, Encryptor,
-};
-use cipher::{BlockCipher, BlockDecrypt, BlockEncryptMut};
+use cfb_mode::{cipher::KeyIvInit, BufEncryptor, Decryptor, Encryptor};
+use cipher::BlockCipherEncrypt;
 use des::TdesEde3;
 use idea::Idea;
 use log::debug;
 use num_enum::{FromPrimitive, IntoPrimitive};
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use twofish::Twofish;
 use zeroize::Zeroizing;
 
@@ -29,7 +26,7 @@ pub use self::{decryptor::StreamDecryptor, encryptor::StreamEncryptor};
 #[cfg(test)]
 fn decrypt<MODE>(key: &[u8], iv: &[u8], prefix: &mut [u8], data: &mut [u8]) -> Result<()>
 where
-    MODE: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    MODE: BlockCipherEncrypt,
     cfb_mode::BufDecryptor<MODE>: KeyIvInit,
 {
     let mut mode = cfb_mode::BufDecryptor::<MODE>::new_from_slices(key, iv)?;
@@ -50,7 +47,7 @@ where
 #[cfg(test)]
 fn decrypt_resync<MODE>(key: &[u8], iv: &[u8], prefix: &mut [u8], data: &mut [u8]) -> Result<()>
 where
-    MODE: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    MODE: BlockCipherEncrypt,
     cfb_mode::BufDecryptor<MODE>: KeyIvInit,
 {
     let mut mode = cfb_mode::BufDecryptor::<MODE>::new_from_slices(key, iv)?;
@@ -71,7 +68,7 @@ where
 
 fn encrypt<MODE>(key: &[u8], iv: &[u8], prefix: &mut [u8], data: &mut [u8]) -> Result<()>
 where
-    MODE: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    MODE: BlockCipherEncrypt,
     BufEncryptor<MODE>: KeyIvInit,
 {
     let mut mode = BufEncryptor::<MODE>::new_from_slices(key, iv)?;
@@ -87,7 +84,7 @@ where
 /// <https://datatracker.ietf.org/doc/html/rfc4880.html#section-13.9>
 fn encrypt_resync<MODE>(key: &[u8], iv: &[u8], prefix: &mut [u8], data: &mut [u8]) -> Result<()>
 where
-    MODE: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    MODE: BlockCipherEncrypt,
     BufEncryptor<MODE>: KeyIvInit,
 {
     let mut mode = BufEncryptor::<MODE>::new_from_slices(key, iv)?;
@@ -431,9 +428,9 @@ impl SymmetricKeyAlgorithm {
 
     /// Encrypt the data using CFB mode, without padding. Overwrites the input.
     /// Uses an IV of all zeroes, as specified in the openpgp cfb mode.
-    pub fn encrypt<R: CryptoRng + Rng>(
+    pub fn encrypt<R: CryptoRng + ?Sized>(
         self,
-        mut rng: R,
+        rng: &mut R,
         key: &[u8],
         plaintext: &[u8],
     ) -> Result<Vec<u8>> {
@@ -462,9 +459,9 @@ impl SymmetricKeyAlgorithm {
         Ok(ciphertext)
     }
 
-    pub fn encrypt_protected<R: CryptoRng + Rng>(
+    pub fn encrypt_protected<R: CryptoRng + ?Sized>(
         self,
-        mut rng: R,
+        rng: &mut R,
         key: &[u8],
         plaintext: &[u8],
     ) -> Result<Vec<u8>> {
@@ -524,12 +521,12 @@ impl SymmetricKeyAlgorithm {
 
     pub fn stream_encryptor<R, I>(
         self,
-        rng: R,
+        rng: &mut R,
         key: &[u8],
         plaintext: I,
     ) -> Result<StreamEncryptor<I>>
     where
-        R: Rng + CryptoRng,
+        R: CryptoRng + ?Sized,
         I: std::io::Read,
     {
         StreamEncryptor::new(rng, self, key, plaintext)
@@ -726,7 +723,7 @@ impl SymmetricKeyAlgorithm {
     }
 
     /// Generate a new session key.
-    pub fn new_session_key<R: Rng + CryptoRng>(self, mut rng: R) -> RawSessionKey {
+    pub fn new_session_key<R: CryptoRng + ?Sized>(self, rng: &mut R) -> RawSessionKey {
         let mut session_key = Zeroizing::new(vec![0u8; self.key_size()]);
         rng.fill_bytes(&mut session_key);
         session_key.into()
@@ -753,9 +750,9 @@ where
 mod tests {
     use std::{io::Read, time::Instant};
 
+    use chacha20::ChaCha8Rng;
     use log::info;
     use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 
@@ -974,7 +971,7 @@ mod tests {
             .is_err());
     }
 
-    use rand::RngCore;
+    use rand::RngExt;
 
     use crate::types::Seipdv1ReadMode;
 

--- a/src/crypto/sym/decryptor.rs
+++ b/src/crypto/sym/decryptor.rs
@@ -11,7 +11,7 @@ use bytes::{Buf, BytesMut};
 use camellia::{Camellia128, Camellia192, Camellia256};
 use cast5::Cast5;
 use cfb_mode::{cipher::KeyIvInit, BufDecryptor};
-use cipher::{BlockCipher, BlockDecrypt, BlockEncryptMut, BlockSizeUser};
+use cipher::{BlockCipherEncrypt, BlockSizeUser};
 use des::TdesEde3;
 use idea::Idea;
 use log::debug;
@@ -288,7 +288,7 @@ pub enum MaybeProtected {
 #[derive(derive_more::Debug)]
 pub enum StreamDecryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufDecryptor<M>: KeyIvInit,
     R: BufRead,
 {
@@ -318,7 +318,7 @@ where
 
 impl<M, R> StreamDecryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufDecryptor<M>: KeyIvInit,
     R: BufRead,
 {
@@ -608,7 +608,7 @@ where
 
 impl<M, R> BufRead for StreamDecryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufDecryptor<M>: KeyIvInit,
     R: BufRead,
 {
@@ -647,7 +647,7 @@ where
 
 impl<M, R> Read for StreamDecryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufDecryptor<M>: KeyIvInit,
     R: BufRead,
 {

--- a/src/crypto/sym/encryptor.rs
+++ b/src/crypto/sym/encryptor.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, Bytes, BytesMut};
 use camellia::{Camellia128, Camellia192, Camellia256};
 use cast5::Cast5;
 use cfb_mode::{cipher::KeyIvInit, BufEncryptor};
-use cipher::{BlockCipher, BlockDecrypt, BlockEncryptMut, BlockSizeUser};
+use cipher::{BlockCipherEncrypt, BlockSizeUser};
 use des::TdesEde3;
 use idea::Idea;
 use log::debug;
@@ -38,8 +38,8 @@ where
 }
 
 impl<R: std::io::Read> StreamEncryptor<R> {
-    pub fn new<B: Rng + CryptoRng>(
-        rng: B,
+    pub fn new<B: CryptoRng + ?Sized>(
+        rng: &mut B,
         alg: SymmetricKeyAlgorithm,
         key: &[u8],
         plaintext: R,
@@ -128,7 +128,7 @@ where
 #[derive(derive_more::Debug)]
 pub enum StreamEncryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufEncryptor<M>: KeyIvInit,
     R: std::io::Read,
 {
@@ -157,13 +157,13 @@ where
 
 impl<M, R> StreamEncryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufEncryptor<M>: KeyIvInit,
     R: std::io::Read,
 {
-    fn new<RAND>(mut rng: RAND, source: R, key: &[u8]) -> Result<Self>
+    fn new<RAND>(rng: &mut RAND, source: R, key: &[u8]) -> Result<Self>
     where
-        RAND: Rng + CryptoRng,
+        RAND: Rng + CryptoRng + ?Sized,
     {
         debug!("protected encrypt stream");
 
@@ -325,7 +325,7 @@ where
 
 impl<M, R> std::io::Read for StreamEncryptorInner<M, R>
 where
-    M: BlockDecrypt + BlockEncryptMut + BlockCipher,
+    M: BlockCipherEncrypt,
     BufEncryptor<M>: KeyIvInit,
     R: std::io::Read,
 {

--- a/src/crypto/x25519.rs
+++ b/src/crypto/x25519.rs
@@ -2,10 +2,10 @@ use std::cmp::PartialEq;
 
 use hkdf::HkdfExtract;
 use log::debug;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use crate::{
     crypto::{aes_kw, Decryptor},
@@ -17,7 +17,7 @@ use crate::{
 pub const KEY_LEN: usize = 32;
 
 /// Secret key for X25519
-#[derive(Clone, derive_more::Debug, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, derive_more::Debug, ZeroizeOnDrop)]
 pub struct SecretKey {
     #[debug("..")]
     secret: StaticSecret,
@@ -41,7 +41,7 @@ impl Eq for SecretKey {}
 
 impl SecretKey {
     /// Generate an X25519 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let mut secret_key_bytes = Zeroizing::new([0u8; 32]);
         rng.fill_bytes(&mut *secret_key_bytes);
 
@@ -164,8 +164,8 @@ pub fn hkdf(
 /// X25519 encryption.
 ///
 /// Returns (ephemeral, encrypted session key)
-pub fn encrypt<R: CryptoRng + Rng>(
-    mut rng: R,
+pub fn encrypt<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     recipient_public: &x25519_dalek::PublicKey,
     plain: &[u8],
 ) -> Result<([u8; 32], Vec<u8>)> {
@@ -208,9 +208,9 @@ pub fn encrypt<R: CryptoRng + Rng>(
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha20Rng;
     use proptest::prelude::*;
-    use rand::{RngCore, SeedableRng};
-    use rand_chacha::ChaChaRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt() {
-        let mut rng = ChaChaRng::from_seed([0u8; 32]);
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
         let skey = SecretKey::generate(&mut rng);
         let pub_params: X25519PublicParams = (&skey).into();
 

--- a/src/crypto/x448.rs
+++ b/src/crypto/x448.rs
@@ -1,7 +1,6 @@
-use cx448::x448;
 use hkdf::HkdfExtract;
 use log::debug;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use sha2::Sha512;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
@@ -18,7 +17,7 @@ pub const KEY_LEN: usize = 56;
 #[derive(Clone, derive_more::Debug, Zeroize, ZeroizeOnDrop)]
 pub struct SecretKey {
     #[debug("..")]
-    secret: x448::Secret,
+    secret: x448::StaticSecret,
 }
 
 impl PartialEq for SecretKey {
@@ -31,22 +30,22 @@ impl Eq for SecretKey {}
 
 impl From<&SecretKey> for X448PublicParams {
     fn from(value: &SecretKey) -> Self {
-        let secret = value.secret;
-        let public = x448::PublicKey::from(&secret);
+        let secret = &value.secret;
+        let public = x448::PublicKey::from(secret);
         X448PublicParams { key: public }
     }
 }
 
 impl SecretKey {
     /// Generate an X448 `SecretKey`.
-    pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let secret = x448::Secret::new(&mut rng);
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        let secret = x448::StaticSecret::random_from_rng(rng);
 
         SecretKey { secret }
     }
 
     pub fn try_from_bytes(secret: [u8; KEY_LEN]) -> Result<Self> {
-        let secret = x448::Secret::from(secret);
+        let secret = x448::StaticSecret::from(secret);
 
         Ok(Self { secret })
     }
@@ -93,12 +92,9 @@ impl Decryptor for SecretKey {
             };
 
             // private key of the recipient.
-            let our_secret = self.secret;
+            let our_secret = &self.secret;
 
-            // derive shared secret (None for low order points)
-            let Some(shared_secret) = our_secret.as_diffie_hellman(&their_public) else {
-                bail!("x448 Secret::as_diffie_hellman returned None");
-            };
+            let shared_secret = our_secret.diffie_hellman(&their_public);
 
             *shared_secret.as_bytes()
         };
@@ -165,8 +161,8 @@ pub fn hkdf(
 /// X448 encryption.
 ///
 /// Returns (ephemeral, encrypted session key)
-pub fn encrypt<R: CryptoRng + Rng>(
-    mut rng: R,
+pub fn encrypt<R: CryptoRng + ?Sized>(
+    rng: &mut R,
     recipient_public: &X448PublicParams,
     plain: &[u8],
 ) -> Result<([u8; 56], Vec<u8>)> {
@@ -186,12 +182,9 @@ pub fn encrypt<R: CryptoRng + Rng>(
 
         let mut ephemeral_secret_key_bytes = Zeroizing::new([0u8; 56]);
         rng.fill_bytes(&mut *ephemeral_secret_key_bytes);
-        let our_secret = x448::Secret::from(*ephemeral_secret_key_bytes);
+        let our_secret = x448::StaticSecret::from(*ephemeral_secret_key_bytes);
 
-        // derive shared secret (None for low order points)
-        let Some(shared_secret) = our_secret.as_diffie_hellman(their_public) else {
-            bail!("x448 Secret::as_diffie_hellman returned None");
-        };
+        let shared_secret = our_secret.diffie_hellman(their_public);
 
         // Encode public point
         let ephemeral_public = x448::PublicKey::from(&our_secret);
@@ -218,15 +211,15 @@ mod tests {
 
     use std::ops::Deref;
 
+    use chacha20::{ChaCha20Rng, ChaCha8Rng};
     use proptest::prelude::*;
-    use rand::{RngCore, SeedableRng};
-    use rand_chacha::{ChaCha8Rng, ChaChaRng};
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
     #[test]
     fn test_encrypt_decrypt() {
-        let mut rng = ChaChaRng::from_seed([0u8; 32]);
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         let skey = SecretKey::generate(&mut rng);
         let pub_params: X448PublicParams = (&skey).into();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -135,7 +135,9 @@ pub enum Error {
         backtrace: Option<Backtrace>,
     },
     #[snafu(transparent)]
-    SigningError { source: cx448::SigningError },
+    SigningError {
+        source: ed448_goldilocks::SigningError,
+    },
 }
 
 impl From<crate::crypto::hash::Error> for Error {
@@ -162,8 +164,8 @@ impl From<cipher::InvalidLength> for Error {
     }
 }
 
-impl From<block_padding::UnpadError> for Error {
-    fn from(_: block_padding::UnpadError) -> Error {
+impl From<block_padding::Error> for Error {
+    fn from(_: block_padding::Error) -> Error {
         Error::UnpadError
     }
 }

--- a/src/line_writer.rs
+++ b/src/line_writer.rs
@@ -2,9 +2,9 @@
 
 use std::io;
 
-use generic_array::{
+use cipher::{
+    array::{Array, ArraySize},
     typenum::{Sum, Unsigned, U2},
-    ArrayLength, GenericArray,
 };
 
 const CRLF: [u8; 2] = *b"\r\n";
@@ -38,9 +38,9 @@ impl AsRef<[u8]> for LineBreak {
 pub struct LineWriter<'a, W, N>
 where
     W: io::Write,
-    N: Unsigned + ArrayLength<u8>,
+    N: Unsigned + ArraySize,
     N: std::ops::Add<U2>,
-    Sum<N, U2>: ArrayLength<u8>,
+    Sum<N, U2>: ArraySize,
 {
     /// Which kind of line break to insert.
     line_break: LineBreak,
@@ -48,10 +48,10 @@ where
     w: &'a mut W,
     /// Holds a partial chunk, if any, after the last `write()`, so that we may then fill the chunk
     /// with the next `write()`, write it, then proceed with the rest of the input normally.
-    extra: GenericArray<u8, N>,
+    extra: Array<u8, N>,
     /// How much of `extra` is occupied, in `[0, N]`.
     extra_len: usize,
-    buffer: GenericArray<u8, Sum<N, U2>>,
+    buffer: Array<u8, Sum<N, U2>>,
     /// True iff partial last chunk has been written.
     finished: bool,
     /// panic safety: don't write again in destructor if writer panicked while we were writing to it
@@ -61,9 +61,9 @@ where
 impl<'a, W, N> LineWriter<'a, W, N>
 where
     W: 'a + io::Write,
-    N: Unsigned + ArrayLength<u8>,
+    N: Unsigned + ArraySize,
     N: std::ops::Add<U2>,
-    Sum<N, U2>: ArrayLength<u8>,
+    Sum<N, U2>: ArraySize,
 {
     /// Creates a new encoder around an existing writer.
     pub fn new(w: &'a mut W, line_break: LineBreak) -> Self {
@@ -108,9 +108,9 @@ where
 impl<'a, W, N> io::Write for LineWriter<'a, W, N>
 where
     W: 'a + io::Write,
-    N: Unsigned + ArrayLength<u8>,
+    N: Unsigned + ArraySize,
     N: std::ops::Add<U2>,
-    Sum<N, U2>: ArrayLength<u8>,
+    Sum<N, U2>: ArraySize,
 {
     fn write(&mut self, input: &[u8]) -> io::Result<usize> {
         if self.finished {
@@ -193,9 +193,9 @@ where
 impl<'a, W, N> Drop for LineWriter<'a, W, N>
 where
     W: 'a + io::Write,
-    N: Unsigned + ArrayLength<u8>,
+    N: Unsigned + ArraySize,
     N: std::ops::Add<U2>,
-    Sum<N, U2>: ArrayLength<u8>,
+    Sum<N, U2>: ArraySize,
 {
     fn drop(&mut self) {
         if !self.panicked {
@@ -212,7 +212,7 @@ mod tests {
     use std::io::Write;
 
     use base64::engine::general_purpose;
-    use generic_array::typenum::{self, U10};
+    use cipher::array::typenum::{self, U10};
 
     use super::*;
 
@@ -256,7 +256,7 @@ mod tests {
         ( $name:ident, $len:ty ) => {
             #[test]
             fn $name() {
-                use rand::{Rng, SeedableRng};
+                use rand::{RngExt, SeedableRng};
                 use rand_xorshift::XorShiftRng;
 
                 let rng = &mut XorShiftRng::from_seed([
@@ -268,7 +268,7 @@ mod tests {
                 {
                     let mut w = LineWriter::<_, $len>::new(&mut buf, LineBreak::Crlf);
                     for i in 0..100 {
-                        let data = (0..i).map(|_| rng.gen()).collect::<Vec<_>>();
+                        let data = (0..i).map(|_| rng.random()).collect::<Vec<_>>();
                         w.write_all(&data).unwrap();
                         list.extend(&data);
                     }

--- a/src/normalize_lines.rs
+++ b/src/normalize_lines.rs
@@ -150,8 +150,8 @@ fn replace_newlines<'a>(input: &'a [u8], replacement: &[u8]) -> Cow<'a, [u8]> {
 mod tests {
     use std::io::Read;
 
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
+    use chacha20::ChaCha8Rng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
     use crate::util::test::{check_strings, random_string, ChaosReader};
@@ -206,7 +206,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(1);
 
         for _ in 0..100 {
-            let size = rng.gen_range(1..10000);
+            let size = rng.random_range(1..10000);
             let input = random_string(&mut rng, size);
             let reader = ChaosReader::new(&mut rng, input.clone());
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -35,9 +35,9 @@
 //!     },
 //!     types::{KeyDetails, KeyVersion, Password, Timestamp},
 //! };
-//! use rand::thread_rng;
+//! use rand::rng;
 //!
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //!
 //! let now = Timestamp::now();
 //!

--- a/src/packet/compressed_data.rs
+++ b/src/packet/compressed_data.rs
@@ -447,9 +447,9 @@ impl<R: io::Read> io::Read for CompressedDataPartialGenerator<R> {
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
     use crate::packet::Packet;

--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -1,9 +1,9 @@
 use std::io::BufRead;
 
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
-use digest::generic_array::GenericArray;
+use hybrid_array::Array;
 use md5::Md5;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use rsa::traits::PublicKeyParts;
 use sha1_checked::Sha1;
 use sha2::Sha256;
@@ -113,9 +113,9 @@ impl PublicKey {
 }
 
 impl EncryptionKey for PublicKey {
-    fn encrypt<R: rand::CryptoRng + rand::Rng>(
+    fn encrypt<R: rand::CryptoRng + ?Sized>(
         &self,
-        rng: R,
+        rng: &mut R,
         plain: &[u8],
         typ: EskType,
     ) -> Result<PkeskBytes> {
@@ -184,9 +184,9 @@ impl PublicSubkey {
     }
 
     /// Produce a Subkey Binding Signature (Type ID 0x18), to bind this subkey to a primary key
-    pub fn sign<R: CryptoRng + Rng, S, K>(
+    pub fn sign<R: CryptoRng + ?Sized, S, K>(
         &self,
-        rng: R,
+        rng: &mut R,
         primary_sec_key: &S,
         primary_pub_key: &K,
         key_pw: &Password,
@@ -242,9 +242,9 @@ impl PublicSubkey {
 }
 
 impl EncryptionKey for PublicSubkey {
-    fn encrypt<R: rand::CryptoRng + rand::Rng>(
+    fn encrypt<R: rand::CryptoRng + ?Sized>(
         &self,
-        rng: R,
+        rng: &mut R,
         plain: &[u8],
         typ: EskType,
     ) -> Result<PkeskBytes> {
@@ -429,9 +429,9 @@ impl PubKeyInner {
     /// Signs a direct key signature or a revocation.
     #[allow(dead_code)]
     // TODO: Expose in public API
-    fn sign<R: CryptoRng + Rng, S>(
+    fn sign<R: CryptoRng + ?Sized, S>(
         &self,
-        mut rng: R,
+        rng: &mut R,
         key: &S,
         key_pw: &Password,
         sig_type: SignatureType,
@@ -439,7 +439,7 @@ impl PubKeyInner {
     where
         S: SigningKey + Serialize,
     {
-        let mut config = SignatureConfig::from_key(&mut rng, key, sig_type)?;
+        let mut config = SignatureConfig::from_key(rng, key, sig_type)?;
         config.hashed_subpackets = vec![
             Subpacket::regular(SubpacketData::SignatureCreationTime(Timestamp::now()))?,
             Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
@@ -467,9 +467,9 @@ impl PubKeyInner {
     }
 }
 
-pub(crate) fn encrypt<R: rand::CryptoRng + rand::Rng, K: KeyDetails>(
+pub(crate) fn encrypt<R: CryptoRng + ?Sized, K: KeyDetails>(
     key: &K,
-    mut rng: R,
+    rng: &mut R,
     plain: &[u8],
     typ: EskType,
 ) -> Result<PkeskBytes> {
@@ -524,7 +524,7 @@ pub(crate) fn encrypt<R: rand::CryptoRng + rand::Rng, K: KeyDetails>(
                 }
             };
 
-            let (ephemeral, session_key) = crypto::x25519::encrypt(&mut rng, &params.key, plain)?;
+            let (ephemeral, session_key) = crypto::x25519::encrypt(rng, &params.key, plain)?;
 
             Ok(PkeskBytes::X25519 {
                 ephemeral,
@@ -545,7 +545,7 @@ pub(crate) fn encrypt<R: rand::CryptoRng + rand::Rng, K: KeyDetails>(
                 }
             };
 
-            let (ephemeral, session_key) = crypto::x448::encrypt(&mut rng, params, plain)?;
+            let (ephemeral, session_key) = crypto::x448::encrypt(rng, params, plain)?;
 
             Ok(PkeskBytes::X448 {
                 ephemeral,
@@ -571,7 +571,7 @@ pub(crate) fn encrypt<R: rand::CryptoRng + rand::Rng, K: KeyDetails>(
 
             let (ecdh_ciphertext, ml_kem_ciphertext, session_key) =
                 crypto::ml_kem768_x25519::encrypt(
-                    &mut rng,
+                    rng,
                     &params.x25519_key,
                     &params.ml_kem_key,
                     plain,
@@ -599,12 +599,7 @@ pub(crate) fn encrypt<R: rand::CryptoRng + rand::Rng, K: KeyDetails>(
             };
 
             let (ecdh_ciphertext, ml_kem_ciphertext, session_key) =
-                crypto::ml_kem1024_x448::encrypt(
-                    &mut rng,
-                    &params.x448_key,
-                    &params.ml_kem_key,
-                    plain,
-                )?;
+                crypto::ml_kem1024_x448::encrypt(rng, &params.x448_key, &params.ml_kem_key, plain)?;
 
             Ok(PkeskBytes::MlKem1024X448 {
                 ecdh_ciphertext,
@@ -698,7 +693,7 @@ impl crate::packet::PacketTrait for PublicSubkey {
 }
 
 impl PubKeyInner {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         let mut hasher = D::new();
 
         use crate::ser::Serialize;
@@ -1007,7 +1002,7 @@ impl KeyDetails for PublicKey {
 }
 
 impl Imprint for PublicKey {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         self.inner.imprint::<D>()
     }
 }
@@ -1049,7 +1044,7 @@ impl KeyDetails for PublicSubkey {
 }
 
 impl Imprint for PublicSubkey {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         self.inner.imprint::<D>()
     }
 }

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -1,8 +1,8 @@
 use std::io::BufRead;
 
-use generic_array::GenericArray;
+use hybrid_array::Array;
 use log::debug;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use super::public::PubKeyInner;
 use crate::{
@@ -170,9 +170,9 @@ impl SecretSubkey {
     ///
     /// This signature is used in an embedded signature subpacket to show that the subkey is
     /// willing to be associated with the primary.
-    pub fn sign_primary_key_binding<R: CryptoRng + Rng, K>(
+    pub fn sign_primary_key_binding<R: CryptoRng + ?Sized, K>(
         &self,
-        rng: R,
+        rng: &mut R,
         pub_key: &K,
         key_pw: &Password,
     ) -> Result<Signature>
@@ -345,7 +345,7 @@ impl KeyDetails for SecretKey {
 }
 
 impl Imprint for SecretKey {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         self.details.imprint::<D>()
     }
 }
@@ -378,7 +378,7 @@ impl KeyDetails for SecretSubkey {
 }
 
 impl Imprint for SecretSubkey {
-    fn imprint<D: KnownDigest>(&self) -> Result<GenericArray<u8, D::OutputSize>> {
+    fn imprint<D: KnownDigest>(&self) -> Result<Array<u8, D::OutputSize>> {
         self.details.imprint::<D>()
     }
 }
@@ -468,9 +468,9 @@ impl SecretKey {
     ///
     /// To change the password on a locked Secret Key packet, it needs to be unlocked
     /// using [Self::remove_password] before calling this function.
-    pub fn set_password<R>(&mut self, rng: R, password: &Password) -> Result<()>
+    pub fn set_password<R>(&mut self, rng: &mut R, password: &Password) -> Result<()>
     where
-        R: rand::Rng + rand::CryptoRng,
+        R: rand::CryptoRng + ?Sized,
     {
         let s2k = crate::types::S2kParams::new_default(rng, self.version());
         Self::set_password_with_s2k(self, password, s2k)
@@ -527,9 +527,9 @@ impl SecretSubkey {
     ///
     /// To change the password on a locked Secret Key packet, it needs to be unlocked
     /// using [Self::remove_password] before calling this function.
-    pub fn set_password<R>(&mut self, rng: R, password: &Password) -> Result<()>
+    pub fn set_password<R>(&mut self, rng: &mut R, password: &Password) -> Result<()>
     where
-        R: rand::Rng + rand::CryptoRng,
+        R: rand::CryptoRng + ?Sized,
     {
         let s2k = crate::types::S2kParams::new_default(rng, self.version());
         Self::set_password_with_s2k(self, password, s2k)
@@ -563,9 +563,9 @@ impl SecretSubkey {
     }
 
     /// Produce a Subkey Binding Signature (Type ID 0x18), to bind this subkey to a primary key
-    pub fn sign<R: CryptoRng + Rng, S, K>(
+    pub fn sign<R: CryptoRng + ?Sized, S, K>(
         &self,
-        mut rng: R,
+        rng: &mut R,
         primary_sec_key: &S,
         primary_pub_key: &K,
         key_pw: &Password,
@@ -577,7 +577,7 @@ impl SecretSubkey {
         K: KeyDetails + Serialize,
     {
         self.details.sign(
-            &mut rng,
+            rng,
             primary_sec_key,
             primary_pub_key,
             key_pw,
@@ -732,8 +732,8 @@ fn create_signature(
 /// Signs a direct key signature or a revocation.
 #[allow(dead_code)]
 // TODO: Expose in public API
-fn sign<R: CryptoRng + Rng, S, K>(
-    mut rng: R,
+fn sign<R: CryptoRng + ?Sized, S, K>(
+    rng: &mut R,
     key: &S,
     key_pw: &Password,
     sig_typ: SignatureType,
@@ -743,7 +743,7 @@ where
     S: SigningKey,
     K: KeyDetails + Serialize,
 {
-    let mut config = SignatureConfig::from_key(&mut rng, key, sig_typ)?;
+    let mut config = SignatureConfig::from_key(rng, key, sig_typ)?;
     config.hashed_subpackets = vec![
         Subpacket::regular(SubpacketData::SignatureCreationTime(Timestamp::now()))?,
         Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
@@ -759,8 +759,8 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use crate::{
         crypto::hash::HashAlgorithm,

--- a/src/packet/literal_data.rs
+++ b/src/packet/literal_data.rs
@@ -706,8 +706,8 @@ impl<R: io::Read> io::Read for LiteralDataPartialGenerator<R> {
 mod tests {
     use std::io::Read;
 
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha20Rng;
+    use chacha20::ChaCha20Rng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
     use crate::{
@@ -829,7 +829,7 @@ mod tests {
 
             let mut generator = LiteralDataGenerator::new(
                 header.clone(),
-                ChaosReader::new(rng.clone(), s.clone()),
+                ChaosReader::new(rng.fork(), s.clone()),
                 None,
                 chunk_size as u32,
             )
@@ -885,7 +885,7 @@ mod tests {
             // 10k tests on Vec<u8> of length 0-99
             let len = count % 100;
 
-            let bytes: Vec<u8> = (1..=len).map(|_| rng.r#gen::<u8>()).collect();
+            let bytes: Vec<u8> = (1..=len).map(|_| rng.random::<u8>()).collect();
 
             let cr = ChaosReader::new(&mut rng, bytes.clone());
             let mut r = Utf8CheckReader::new(cr);

--- a/src/packet/padding.rs
+++ b/src/packet/padding.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead};
 use bytes::Bytes;
 #[cfg(test)]
 use proptest::prelude::*;
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use crate::{
     errors::Result,
@@ -41,8 +41,8 @@ impl Padding {
     }
 
     /// Create a new padding packet of `size` in bytes.
-    pub fn new<R: CryptoRng + RngCore>(
-        mut rng: R,
+    pub fn new<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         packet_version: PacketHeaderVersion,
         size: usize,
     ) -> Result<Self> {
@@ -79,8 +79,8 @@ impl PacketTrait for Padding {
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha20Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha20Rng;
 
     use super::*;
     use crate::{

--- a/src/packet/public_key_encrypted_session_key.rs
+++ b/src/packet/public_key_encrypted_session_key.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead};
 
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use zeroize::Zeroizing;
 
 use crate::{
@@ -163,8 +163,8 @@ impl PublicKeyEncryptedSessionKey {
     }
 
     /// Encrypts the given session key to `pkey` as a v3 pkesk.
-    pub fn from_session_key_v3<R: CryptoRng + Rng, E: EncryptionKey>(
-        rng: R,
+    pub fn from_session_key_v3<R: CryptoRng + ?Sized, E: EncryptionKey>(
+        rng: &mut R,
         session_key: &RawSessionKey,
         alg: SymmetricKeyAlgorithm,
         enc: &E,
@@ -189,8 +189,8 @@ impl PublicKeyEncryptedSessionKey {
     }
 
     /// Encrypts the given session key to `pkey` as a v6 pkesk.
-    pub fn from_session_key_v6<R: CryptoRng + Rng, E: EncryptionKey>(
-        rng: R,
+    pub fn from_session_key_v6<R: CryptoRng + ?Sized, E: EncryptionKey>(
+        rng: &mut R,
         session_key: &RawSessionKey,
         enc: &E,
     ) -> Result<Self> {

--- a/src/packet/signature/config.rs
+++ b/src/packet/signature/config.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use byteorder::{BigEndian, ByteOrder};
 use digest::DynDigest;
 use log::debug;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     crypto::{
@@ -93,14 +93,14 @@ impl From<&SignatureVersionSpecific> for SignatureVersion {
 }
 
 impl SignatureConfig {
-    pub fn from_key<R: CryptoRng + Rng, S: SigningKey>(
-        mut rng: R,
+    pub fn from_key<R: CryptoRng + ?Sized, S: SigningKey>(
+        rng: &mut R,
         key: &S,
         typ: SignatureType,
     ) -> Result<Self> {
         match key.version() {
             KeyVersion::V4 => Ok(SignatureConfig::v4(typ, key.algorithm(), key.hash_alg())),
-            KeyVersion::V6 => SignatureConfig::v6(&mut rng, typ, key.algorithm(), key.hash_alg()),
+            KeyVersion::V6 => SignatureConfig::v6(rng, typ, key.algorithm(), key.hash_alg()),
             v => unsupported_err!("unsupported key version: {:?}", v),
         }
     }
@@ -168,7 +168,7 @@ impl SignatureConfig {
 
     /// Generate v6 signature salt with the appropriate length for `hash_alg`
     /// https://www.rfc-editor.org/rfc/rfc9580.html#name-hash-algorithms
-    fn v6_salt_for<R: CryptoRng + Rng>(mut rng: R, hash_alg: HashAlgorithm) -> Result<Vec<u8>> {
+    fn v6_salt_for<R: CryptoRng + ?Sized>(rng: &mut R, hash_alg: HashAlgorithm) -> Result<Vec<u8>> {
         let Some(salt_len) = hash_alg.salt_len() else {
             bail!("Unknown v6 signature salt length for hash algorithm {hash_alg:?}");
         };
@@ -183,8 +183,8 @@ impl SignatureConfig {
     /// Generates a new salt via `rng`.
     ///
     /// OpenPGP v6 signatures are specified in RFC 9580, they are produced by OpenPGP v6 keys.
-    pub fn v6<R: CryptoRng + Rng>(
-        rng: R,
+    pub fn v6<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         typ: SignatureType,
         pub_alg: PublicKeyAlgorithm,
         hash_alg: HashAlgorithm,
@@ -812,8 +812,8 @@ impl std::io::Write for SignatureHasher {
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use crate::{
         composed::{ArmorOptions, KeyType, SecretKeyParamsBuilder, SignedPublicKey},

--- a/src/packet/sym_encrypted_protected_data.rs
+++ b/src/packet/sym_encrypted_protected_data.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead, Read};
 
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
-use rand::{CryptoRng, Rng};
+use rand::{CryptoRng, RngExt};
 
 use crate::{
     crypto::{
@@ -125,8 +125,8 @@ impl SymEncryptedProtectedData {
     }
 
     /// Encrypts the data using the given symmetric key.
-    pub fn encrypt_seipdv1<R: CryptoRng + Rng>(
-        rng: R,
+    pub fn encrypt_seipdv1<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         alg: SymmetricKeyAlgorithm,
         key: &[u8],
         plaintext: &[u8],
@@ -145,8 +145,8 @@ impl SymEncryptedProtectedData {
     }
 
     /// Encrypts the data using the given symmetric key.
-    pub fn encrypt_seipdv2<R: CryptoRng + Rng>(
-        mut rng: R,
+    pub fn encrypt_seipdv2<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         sym_alg: SymmetricKeyAlgorithm,
         aead: AeadAlgorithm,
         chunk_size: ChunkSize,
@@ -421,9 +421,9 @@ impl<R: BufRead> StreamDecryptor<R> {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use chacha20::ChaCha8Rng;
     use proptest::{collection::vec, prelude::*};
-    use rand::{RngCore, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::{

--- a/src/packet/sym_key_encrypted_session_key.rs
+++ b/src/packet/sym_key_encrypted_session_key.rs
@@ -5,7 +5,7 @@ use bytes::{Bytes, BytesMut};
 use log::debug;
 #[cfg(test)]
 use proptest::prelude::*;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 use sha2::Sha256;
 use zeroize::Zeroizing;
 
@@ -323,8 +323,8 @@ impl SymKeyEncryptedSessionKey {
     /// Encrypt a session key to a password as a Version 6 Symmetric Key Encrypted Session Key Packet
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc9580.html#name-version-6-symmetric-key-enc>
-    pub fn encrypt_v6<R: CryptoRng + Rng>(
-        mut rng: R,
+    pub fn encrypt_v6<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         msg_pw: &Password,
         session_key: &RawSessionKey,
         s2k: StringToKey,
@@ -635,8 +635,8 @@ impl PacketTrait for SymKeyEncryptedSessionKey {
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::crypto::hash::HashAlgorithm;

--- a/src/packet/user_attribute.rs
+++ b/src/packet/user_attribute.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead};
 use byteorder::{LittleEndian, WriteBytesExt};
 use bytes::Bytes;
 use num_enum::{FromPrimitive, IntoPrimitive};
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     errors::{ensure, ensure_eq, Result},
@@ -238,13 +238,13 @@ impl UserAttribute {
     /// Create a self-signature
     pub fn sign<R, P, K>(
         &self,
-        rng: R,
+        rng: &mut R,
         signer_sec_key: &P,
         signer_pub_key: &K,
         key_pw: &Password,
     ) -> Result<SignedUserAttribute>
     where
-        R: CryptoRng + Rng,
+        R: CryptoRng + ?Sized,
         P: SigningKey,
         K: KeyDetails + Serialize,
     {
@@ -262,14 +262,14 @@ impl UserAttribute {
     /// Create a third-party signature
     pub fn sign_third_party<R, P, K>(
         &self,
-        mut rng: R,
+        rng: &mut R,
         signer: &P,
         signer_pw: &Password,
         signee: &K,
         typ: SignatureType,
     ) -> Result<SignedUserAttribute>
     where
-        R: CryptoRng + Rng,
+        R: CryptoRng + ?Sized,
         P: SigningKey,
         K: KeyDetails + Serialize,
     {
@@ -283,7 +283,7 @@ impl UserAttribute {
             Subpacket::regular(SubpacketData::IssuerFingerprint(signer.fingerprint()))?,
         ];
 
-        let mut config = SignatureConfig::from_key(&mut rng, signer, typ)?;
+        let mut config = SignatureConfig::from_key(rng, signer, typ)?;
 
         config.hashed_subpackets = hashed_subpackets;
         if signer.version() <= KeyVersion::V4 {

--- a/src/packet/user_id.rs
+++ b/src/packet/user_id.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     errors::{ensure, Result},
@@ -106,13 +106,13 @@ impl UserId {
     /// Create a self-signature.
     pub fn sign<R, S, K>(
         &self,
-        rng: R,
+        rng: &mut R,
         signer_sec_key: &S,
         signer_pub_key: &K,
         key_pw: &Password,
     ) -> Result<SignedUser>
     where
-        R: CryptoRng + Rng,
+        R: CryptoRng + ?Sized,
         S: SigningKey,
         K: KeyDetails + Serialize,
     {
@@ -130,14 +130,14 @@ impl UserId {
     /// Create a third-party signature.
     pub fn sign_third_party<R, S, K>(
         &self,
-        mut rng: R,
+        rng: &mut R,
         signer: &S,
         signer_pw: &Password,
         signee: &K,
         typ: SignatureType,
     ) -> Result<SignedUser>
     where
-        R: CryptoRng + Rng,
+        R: CryptoRng + ?Sized,
         S: SigningKey,
         K: KeyDetails + Serialize,
     {
@@ -151,7 +151,7 @@ impl UserId {
             Subpacket::regular(SubpacketData::IssuerFingerprint(signer.fingerprint()))?,
         ];
 
-        let mut config = SignatureConfig::from_key(&mut rng, signer, typ)?;
+        let mut config = SignatureConfig::from_key(rng, signer, typ)?;
 
         config.hashed_subpackets = hashed_subpackets;
         if signer.version() <= KeyVersion::V4 {
@@ -191,9 +191,9 @@ impl PacketTrait for UserId {
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::{

--- a/src/types/key_traits.rs
+++ b/src/types/key_traits.rs
@@ -1,4 +1,4 @@
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     composed::PlainSessionKey,
@@ -57,7 +57,7 @@ pub trait Imprint {
     ///
     /// NOTE: Imprints are a special purpose tool! For most use cases, the OpenPGP [`Fingerprint`]
     /// is the most appropriate identifier for a certificate or a component key.
-    fn imprint<D: KnownDigest>(&self) -> Result<generic_array::GenericArray<u8, D::OutputSize>>;
+    fn imprint<D: KnownDigest>(&self) -> Result<hybrid_array::Array<u8, D::OutputSize>>;
 }
 
 /// Keys that can verify signatures.
@@ -168,18 +168,18 @@ impl SigningKey for Box<&dyn SigningKey> {
 /// Describes keys that can encrypt plain data (i.e. a session key) into data for a
 /// [PKESK](https://www.rfc-editor.org/rfc/rfc9580#name-public-key-encrypted-sessio).
 pub trait EncryptionKey: KeyDetails {
-    fn encrypt<R: rand::CryptoRng + rand::Rng>(
+    fn encrypt<R: CryptoRng + ?Sized>(
         &self,
-        rng: R,
+        rng: &mut R,
         plain: &[u8],
         typ: EskType,
     ) -> crate::errors::Result<PkeskBytes>;
 }
 
 impl<T: EncryptionKey> EncryptionKey for &T {
-    fn encrypt<R: CryptoRng + Rng>(
+    fn encrypt<R: CryptoRng + ?Sized>(
         &self,
-        rng: R,
+        rng: &mut R,
         plain: &[u8],
         typ: EskType,
     ) -> Result<PkeskBytes> {

--- a/src/types/mpi.rs
+++ b/src/types/mpi.rs
@@ -2,7 +2,8 @@ use std::io::{self, BufRead};
 
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::{Buf, Bytes};
-use num_bigint::BigUint;
+use crypto_bigint::{NonZero, Odd};
+use rsa::BoxedUint;
 
 use crate::{
     errors::{InvalidInputSnafu, Result},
@@ -115,21 +116,96 @@ impl Serialize for Mpi {
     }
 }
 
-impl From<BigUint> for Mpi {
-    fn from(other: BigUint) -> Self {
-        Mpi(other.to_bytes_be().into())
+impl From<BoxedUint> for Mpi {
+    fn from(other: BoxedUint) -> Self {
+        Self::from(&other)
     }
 }
 
-impl From<&BigUint> for Mpi {
-    fn from(other: &BigUint) -> Self {
-        Mpi(other.to_bytes_be().into())
+impl From<&BoxedUint> for Mpi {
+    fn from(other: &BoxedUint) -> Self {
+        // TODO(baloo): are Mpi used for private keys?
+        //              This is only meant to be used for public keys
+        Mpi(other.to_be_bytes_trimmed_vartime().into())
     }
 }
 
-impl From<Mpi> for BigUint {
+impl From<NonZero<BoxedUint>> for Mpi {
+    fn from(other: NonZero<BoxedUint>) -> Self {
+        Self::from(other.get())
+    }
+}
+
+impl From<&NonZero<BoxedUint>> for Mpi {
+    fn from(other: &NonZero<BoxedUint>) -> Self {
+        Self::from(other.as_ref())
+    }
+}
+
+impl From<Odd<BoxedUint>> for Mpi {
+    fn from(other: Odd<BoxedUint>) -> Self {
+        Mpi(other.to_be_bytes().into())
+    }
+}
+
+impl From<&Odd<BoxedUint>> for Mpi {
+    fn from(other: &Odd<BoxedUint>) -> Self {
+        Mpi(other.to_be_bytes().into())
+    }
+}
+
+impl From<&Mpi> for BoxedUint {
+    fn from(other: &Mpi) -> Self {
+        let bytes = other.as_ref();
+        BoxedUint::from_be_slice(
+            bytes,
+            (bytes.len() * 8)
+                .try_into()
+                .expect("invariant violated, MPI should only be MAX_EXTERN_MPI_BITS long"),
+        )
+        .expect("invariant violated, MPI should only be MAX_EXTERN_MPI_BITS long")
+    }
+}
+
+impl From<Mpi> for BoxedUint {
     fn from(other: Mpi) -> Self {
-        BigUint::from_bytes_be(other.as_ref())
+        Self::from(&other)
+    }
+}
+
+impl TryFrom<&Mpi> for NonZero<BoxedUint> {
+    type Error = signature::Error;
+
+    fn try_from(other: &Mpi) -> Result<Self, Self::Error> {
+        Self::new(BoxedUint::from(other))
+            .into_option()
+            .ok_or(signature::Error::new())
+    }
+}
+
+impl TryFrom<Mpi> for NonZero<BoxedUint> {
+    type Error = signature::Error;
+
+    fn try_from(other: Mpi) -> Result<Self, Self::Error> {
+        Self::try_from(&other)
+    }
+}
+
+impl TryFrom<&Mpi> for Odd<BoxedUint> {
+    type Error = signature::Error;
+
+    fn try_from(other: &Mpi) -> Result<Self, Self::Error> {
+        Self::new(BoxedUint::from(other))
+            .into_option()
+            .ok_or(signature::Error::new())
+    }
+}
+
+impl TryFrom<Mpi> for Odd<BoxedUint> {
+    type Error = signature::Error;
+
+    fn try_from(other: Mpi) -> Result<Self, Self::Error> {
+        Self::try_from(&other)
     }
 }
 
@@ -187,7 +263,7 @@ mod tests {
             println!("fixture {i}");
             let n = hex::decode(raw).unwrap();
 
-            let n_big = BigUint::from_bytes_be(&n);
+            let n_big = BoxedUint::from_be_slice(&n, (n.len() * 8).try_into().unwrap()).unwrap();
             let n_mpi: Mpi = n_big.clone().into();
             let mut n_encoded = Vec::new();
             n_mpi.to_writer(&mut n_encoded).unwrap();
@@ -195,7 +271,7 @@ mod tests {
             assert_eq!(&n_encoded, &hex::decode(encoded).unwrap());
 
             let n_big2 = Mpi::try_from_reader(&mut &n_encoded[..]).unwrap();
-            assert_eq!(n_big, n_big2.into());
+            assert_eq!(n_big, BoxedUint::from(n_big2));
         }
     }
 

--- a/src/types/params/public/dsa.rs
+++ b/src/types/params/public/dsa.rs
@@ -54,7 +54,7 @@ impl DsaPublicParams {
     }
 
     pub(crate) fn try_from_mpi(p: Mpi, q: Mpi, g: Mpi, y: Mpi) -> Result<Self> {
-        let components = dsa::Components::from_components(p.into(), q.into(), g.into())?;
+        let components = dsa::Components::from_components_unchecked(p.into(), q.into(), g.into())?;
         let key = dsa::VerifyingKey::from_components(components, y.into())?;
 
         Ok(DsaPublicParams { key })

--- a/src/types/params/public/dsa.rs
+++ b/src/types/params/public/dsa.rs
@@ -101,10 +101,10 @@ mod tests {
 
     prop_compose! {
         pub fn dsa_pub_gen()(seed: u64) -> dsa::VerifyingKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
             #[allow(deprecated)]
-            let components = dsa::Components::generate(&mut rng, dsa::KeySize::DSA_1024_160);
-            let signing_key = dsa::SigningKey::generate(&mut rng, components);
+            let Ok(components) = dsa::Components::try_generate_from_rng_with_key_size(&mut rng, dsa::KeySize::DSA_1024_160);
+            let Ok(signing_key) = dsa::SigningKey::try_generate_from_rng_with_components(&mut rng, components);
             signing_key.verifying_key().clone()
         }
     }

--- a/src/types/params/public/ecdh.rs
+++ b/src/types/params/public/ecdh.rs
@@ -408,14 +408,15 @@ impl EcdhPublicParams {
 
 #[cfg(test)]
 pub(super) mod tests {
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
-    use rand::{RngCore, SeedableRng};
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
     proptest::prop_compose! {
         pub fn ecdh_curve25519_gen()(seed: u64) -> x25519_dalek::PublicKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+             let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
             let mut secret_key_bytes = [0u8; 32];
             rng.fill_bytes(&mut secret_key_bytes);
 
@@ -426,22 +427,22 @@ pub(super) mod tests {
 
     proptest::prop_compose! {
         pub fn ecdh_p256_gen()(seed: u64) -> elliptic_curve::PublicKey<p256::NistP256> {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            elliptic_curve::SecretKey::<p256::NistP256>::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            elliptic_curve::SecretKey::<p256::NistP256>::generate_from_rng(&mut rng).public_key()
         }
     }
 
     proptest::prop_compose! {
         pub fn ecdh_p384_gen()(seed: u64) -> elliptic_curve::PublicKey<p384::NistP384> {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            elliptic_curve::SecretKey::<p384::NistP384>::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            elliptic_curve::SecretKey::<p384::NistP384>::generate_from_rng(&mut rng).public_key()
         }
     }
 
     proptest::prop_compose! {
         pub fn ecdh_p521_gen()(seed: u64) -> elliptic_curve::PublicKey<p521::NistP521> {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            elliptic_curve::SecretKey::<p521::NistP521>::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            elliptic_curve::SecretKey::<p521::NistP521>::generate_from_rng(&mut rng).public_key()
         }
     }
 

--- a/src/types/params/public/ecdsa.rs
+++ b/src/types/params/public/ecdsa.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead};
 
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::sec1::ToSec1Point;
 
 use crate::{
     crypto::ecc_curve::{ecc_curve_from_oid, ECCCurve},
@@ -144,19 +144,19 @@ impl Serialize for EcdsaPublicParams {
 
         match self {
             EcdsaPublicParams::P256 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 p.to_writer(writer)?;
             }
             EcdsaPublicParams::P384 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 p.to_writer(writer)?;
             }
             EcdsaPublicParams::P521 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 p.to_writer(writer)?;
             }
             EcdsaPublicParams::Secp256k1 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 p.to_writer(writer)?;
             }
             EcdsaPublicParams::Unsupported { opaque, .. } => {
@@ -181,19 +181,19 @@ impl Serialize for EcdsaPublicParams {
 
         match self {
             EcdsaPublicParams::P256 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 sum += p.write_len();
             }
             EcdsaPublicParams::P384 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 sum += p.write_len();
             }
             EcdsaPublicParams::P521 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 sum += p.write_len();
             }
             EcdsaPublicParams::Secp256k1 { key, .. } => {
-                let p = Mpi::from_slice(key.to_encoded_point(false).as_bytes());
+                let p = Mpi::from_slice(key.to_sec1_point(false).as_bytes());
                 sum += p.write_len();
             }
             EcdsaPublicParams::Unsupported { opaque, .. } => {
@@ -206,6 +206,7 @@ impl Serialize for EcdsaPublicParams {
 
 #[cfg(test)]
 mod tests {
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
     use rand::SeedableRng;
 
@@ -213,29 +214,29 @@ mod tests {
 
     proptest::prop_compose! {
         pub fn p256_pub_gen()(seed: u64) -> p256::PublicKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p256::SecretKey::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p256::SecretKey::generate_from_rng(&mut rng).public_key()
         }
     }
 
     proptest::prop_compose! {
         pub fn p384_pub_gen()(seed: u64) -> p384::PublicKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p384::SecretKey::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p384::SecretKey::generate_from_rng(&mut rng).public_key()
         }
     }
 
     proptest::prop_compose! {
         pub fn p521_pub_gen()(seed: u64) -> p521::PublicKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            p521::SecretKey::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            p521::SecretKey::generate_from_rng(&mut rng).public_key()
         }
     }
 
     proptest::prop_compose! {
         pub fn k256_pub_gen()(seed: u64) -> k256::PublicKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            k256::SecretKey::random(&mut rng).public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            k256::SecretKey::generate_from_rng(&mut rng).public_key()
         }
     }
 

--- a/src/types/params/public/ed448.rs
+++ b/src/types/params/public/ed448.rs
@@ -40,8 +40,8 @@ mod tests {
     use super::*;
 
     proptest::prop_compose! {
-        pub fn ed448_pub_gen()(bytes: [u8; 57]) -> ed448_goldilocks::VerifyingKey {
-            let secret = ed448_goldilocks::SigningKey::from(ed448_goldilocks::EdwardsScalarBytes::clone_from_slice(&bytes));
+         pub fn ed448_pub_gen()(bytes: [u8; 57]) -> ed448_goldilocks::VerifyingKey {
+            let secret = ed448_goldilocks::SigningKey::from(ed448_goldilocks::EdwardsScalarBytes::try_from(&bytes[..]).expect("invariant violation"));
             secret.verifying_key()
         }
     }

--- a/src/types/params/public/ed448.rs
+++ b/src/types/params/public/ed448.rs
@@ -7,7 +7,7 @@ use crate::{errors::Result, parsing_reader::BufReadParsing, ser::Serialize};
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Ed448PublicParams {
     #[cfg_attr(test, proptest(strategy = "tests::ed448_pub_gen()"))]
-    pub key: cx448::VerifyingKey,
+    pub key: ed448_goldilocks::VerifyingKey,
 }
 
 impl Ed448PublicParams {
@@ -15,7 +15,7 @@ impl Ed448PublicParams {
     pub fn try_from_reader<B: BufRead>(mut i: B) -> Result<Self> {
         // 57 bytes of public key
         let p = i.read_arr::<57>()?;
-        let key = cx448::VerifyingKey::from_bytes(&p)?;
+        let key = ed448_goldilocks::VerifyingKey::from_bytes(&p)?;
         let params = Self { key };
 
         Ok(params)
@@ -40,8 +40,8 @@ mod tests {
     use super::*;
 
     proptest::prop_compose! {
-        pub fn ed448_pub_gen()(bytes: [u8; 57]) -> cx448::VerifyingKey {
-            let secret = cx448::SigningKey::from(cx448::SecretKey::clone_from_slice(&bytes));
+        pub fn ed448_pub_gen()(bytes: [u8; 57]) -> ed448_goldilocks::VerifyingKey {
+            let secret = ed448_goldilocks::SigningKey::from(ed448_goldilocks::EdwardsScalarBytes::clone_from_slice(&bytes));
             secret.verifying_key()
         }
     }

--- a/src/types/params/public/ml_dsa65_ed25519.rs
+++ b/src/types/params/public/ml_dsa65_ed25519.rs
@@ -48,9 +48,10 @@ impl Serialize for MlDsa65Ed25519PublicParams {
 
 #[cfg(test)]
 mod tests {
-    use ml_dsa::KeyGen;
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
     use rand::SeedableRng;
+    use signature::Keypair;
 
     use super::*;
 
@@ -60,10 +61,10 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> MlDsa65Ed25519PublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
 
                 let x = ed25519_dalek::SigningKey::generate(&mut rng);
-                let ml = MlDsa65::key_gen(&mut rng);
+                let ml = ml_dsa::SigningKey::<MlDsa65>::generate_from_rng(&mut rng);
 
                 MlDsa65Ed25519PublicParams {
                     ed25519: x.verifying_key(),

--- a/src/types/params/public/ml_dsa87_ed448.rs
+++ b/src/types/params/public/ml_dsa87_ed448.rs
@@ -7,7 +7,7 @@ use crate::{errors::Result, parsing_reader::BufReadParsing, ser::Serialize};
 #[derive(derive_more::Debug, PartialEq, Clone)]
 pub struct MlDsa87Ed448PublicParams {
     #[debug("{}", hex::encode(ed448.as_bytes()))]
-    pub ed448: cx448::VerifyingKey,
+    pub ed448: ed448_goldilocks::VerifyingKey,
     #[debug("{}", hex::encode(ml_dsa.encode()))]
     pub ml_dsa: Box<ml_dsa::VerifyingKey<MlDsa87>>,
 }
@@ -18,7 +18,7 @@ impl MlDsa87Ed448PublicParams {
     pub fn try_from_reader<B: BufRead>(mut i: B) -> Result<Self> {
         // ed448 public key
         let p = i.read_arr::<57>()?;
-        let ed448 = cx448::VerifyingKey::from_bytes(&p)?;
+        let ed448 = ed448_goldilocks::VerifyingKey::from_bytes(&p)?;
 
         // ML DSA key
         let p = i.read_arr::<2592>()?;
@@ -45,9 +45,10 @@ impl Serialize for MlDsa87Ed448PublicParams {
 
 #[cfg(test)]
 mod tests {
-    use ml_dsa::KeyGen;
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
     use rand::SeedableRng;
+    use signature::Keypair;
 
     use super::*;
 
@@ -57,10 +58,10 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> MlDsa87Ed448PublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
 
-                let x = cx448::SigningKey::generate(&mut rng);
-                let ml = MlDsa87::key_gen(&mut rng);
+                let x = ed448_goldilocks::SigningKey::generate_from_rng(&mut rng);
+                let ml = ml_dsa::SigningKey::<MlDsa87>::generate_from_rng(&mut rng);
 
                 MlDsa87Ed448PublicParams {
                     ed448: x.verifying_key(),

--- a/src/types/params/public/ml_kem768_x25519.rs
+++ b/src/types/params/public/ml_kem768_x25519.rs
@@ -1,8 +1,12 @@
 use std::io::{self, BufRead};
 
-use ml_kem::{kem::EncapsulationKey, EncodedSizeUser, MlKem768Params};
+use ml_kem::{EncapsulationKey, KeyExport, MlKem768};
 
-use crate::{errors::Result, parsing_reader::BufReadParsing, ser::Serialize};
+use crate::{
+    errors::{format_err, Result},
+    parsing_reader::BufReadParsing,
+    ser::Serialize,
+};
 
 const ML_KEM_PUB_KEY_LENGTH: usize = 1184;
 
@@ -10,8 +14,8 @@ const ML_KEM_PUB_KEY_LENGTH: usize = 1184;
 pub struct MlKem768X25519PublicParams {
     #[debug("{}", hex::encode(x25519_key.as_bytes()))]
     pub x25519_key: x25519_dalek::PublicKey,
-    #[debug("{}", hex::encode(ml_kem_key.as_bytes()))]
-    pub ml_kem_key: Box<EncapsulationKey<MlKem768Params>>,
+    #[debug("{}", hex::encode(ml_kem_key.to_bytes()))]
+    pub ml_kem_key: Box<EncapsulationKey<MlKem768>>,
 }
 
 impl Eq for MlKem768X25519PublicParams {}
@@ -22,7 +26,8 @@ impl MlKem768X25519PublicParams {
         let x25519_public_raw = i.read_arr::<32>()?;
 
         let ml_kem_raw = i.read_arr::<ML_KEM_PUB_KEY_LENGTH>()?;
-        let ml_kem_key = EncapsulationKey::from_bytes(&ml_kem_raw.into());
+        let ml_kem_key = EncapsulationKey::new(&ml_kem_raw.into())
+            .map_err(|_| format_err!("Invalid x25519 key"))?;
 
         Ok(Self {
             x25519_key: x25519_dalek::PublicKey::from(x25519_public_raw),
@@ -34,7 +39,7 @@ impl MlKem768X25519PublicParams {
 impl Serialize for MlKem768X25519PublicParams {
     fn to_writer<W: io::Write>(&self, writer: &mut W) -> Result<()> {
         writer.write_all(self.x25519_key.as_bytes())?;
-        writer.write_all(&self.ml_kem_key.as_bytes())?;
+        writer.write_all(&self.ml_kem_key.to_bytes())?;
         Ok(())
     }
 
@@ -45,9 +50,9 @@ impl Serialize for MlKem768X25519PublicParams {
 
 #[cfg(test)]
 mod tests {
-    use ml_kem::{KemCore, MlKem768};
+    use ml_kem::{Kem, MlKem768};
     use proptest::prelude::*;
-    use rand::SeedableRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -57,13 +62,13 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> MlKem768X25519PublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
                 let mut secret_key_bytes = [0u8; 32];
                 rng.fill_bytes(&mut secret_key_bytes);
 
                 let secret = x25519_dalek::StaticSecret::from(secret_key_bytes);
                 let x = x25519_dalek::PublicKey::from(&secret);
-                let (_, ml) = MlKem768::generate(&mut rng);
+                let (_, ml) = MlKem768::generate_keypair_from_rng(&mut rng);
 
                 MlKem768X25519PublicParams {
                     x25519_key: x,

--- a/src/types/params/public/rsa.rs
+++ b/src/types/params/public/rsa.rs
@@ -66,8 +66,8 @@ mod tests {
 
     prop_compose! {
         pub fn rsa_pub_gen()(seed: u64) -> rsa::RsaPublicKey {
-            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            rsa::RsaPrivateKey::new(&mut rng, 512).unwrap().to_public_key()
+            let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
+            rsa::RsaPrivateKey::new(&mut rng, 1024).unwrap().to_public_key()
         }
     }
 

--- a/src/types/params/public/slh_dsa_shake128f.rs
+++ b/src/types/params/public/slh_dsa_shake128f.rs
@@ -45,7 +45,7 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> SlhDsaShake128fPublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
 
                 let key = slh_dsa::SigningKey::new(&mut rng);
 

--- a/src/types/params/public/slh_dsa_shake128s.rs
+++ b/src/types/params/public/slh_dsa_shake128s.rs
@@ -45,7 +45,7 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> SlhDsaShake128sPublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
 
                 let key = slh_dsa::SigningKey::new(&mut rng);
 

--- a/src/types/params/public/slh_dsa_shake256s.rs
+++ b/src/types/params/public/slh_dsa_shake256s.rs
@@ -45,7 +45,7 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> SlhDsaShake256sPublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
 
                 let key = slh_dsa::SigningKey::new(&mut rng);
 

--- a/src/types/params/public/x448.rs
+++ b/src/types/params/public/x448.rs
@@ -1,7 +1,5 @@
 use std::io::{self, BufRead};
 
-use cx448::x448;
-
 use crate::{
     errors::{format_err, Result},
     parsing_reader::BufReadParsing,
@@ -41,6 +39,7 @@ impl Serialize for X448PublicParams {
 
 #[cfg(test)]
 mod tests {
+    use elliptic_curve::Generate;
     use proptest::prelude::*;
     use rand::SeedableRng;
 
@@ -52,9 +51,9 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> X448PublicParams {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(seed);
 
-                let secret = x448::Secret::new(&mut rng);
+                let secret = x448::EphemeralSecret::generate_from_rng(&mut rng);
                 X448PublicParams {
                     key: (&secret).into(),
                 }

--- a/src/types/pkesk.rs
+++ b/src/types/pkesk.rs
@@ -62,7 +62,7 @@ pub enum PkeskBytes {
     MlKem1024X448 {
         /// Ephemeral X448public key (32 bytes).
         #[debug("{}", hex::encode(ecdh_ciphertext.as_bytes()))]
-        ecdh_ciphertext: cx448::x448::PublicKey,
+        ecdh_ciphertext: x448::PublicKey,
         #[debug("{}", hex::encode(&ml_kem_ciphertext[..]))]
         ml_kem_ciphertext: Box<[u8; 1568]>,
         /// Encrypted and wrapped session key.
@@ -218,7 +218,7 @@ impl PkeskBytes {
                 // A fixed-length octet string representing an ECDH ephemeral public key in the format associated with
                 // the curve as specified in Section 4.1.1.
                 let ephemeral_public = i.read_arr::<56>()?;
-                let ephemeral_public = cx448::x448::PublicKey::from_bytes(&ephemeral_public)
+                let ephemeral_public = x448::PublicKey::from_bytes(&ephemeral_public)
                     .ok_or_else(|| crate::errors::format_err!("invalid x448 public key"))?;
 
                 // A fixed-length octet string of the ML-KEM ciphertext, whose length depends on the algorithm ID as specified in Table 4.

--- a/src/types/s2k.rs
+++ b/src/types/s2k.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead};
 
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
-use rand::{CryptoRng, Rng};
+use rand::{CryptoRng, RngExt};
 use zeroize::Zeroizing;
 
 use crate::{
@@ -97,7 +97,7 @@ impl S2kParams {
     /// - AES256
     /// - CFB
     /// - Iterated and Salted with 224 rounds
-    pub fn new_default<R: Rng + CryptoRng>(mut rng: R, key_version: KeyVersion) -> Self {
+    pub fn new_default<R: CryptoRng + ?Sized>(rng: &mut R, key_version: KeyVersion) -> Self {
         match key_version {
             KeyVersion::V6 => {
                 let sym_alg = SymmetricKeyAlgorithm::AES256;
@@ -214,12 +214,12 @@ pub enum StringToKey {
 }
 
 impl StringToKey {
-    pub fn new_default<R: CryptoRng + Rng>(rng: R) -> Self {
+    pub fn new_default<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         StringToKey::new_iterated(rng, HashAlgorithm::default(), DEFAULT_ITER_SALTED_COUNT)
     }
 
-    pub fn new_iterated<R: CryptoRng + Rng>(
-        mut rng: R,
+    pub fn new_iterated<R: CryptoRng + ?Sized>(
+        rng: &mut R,
         hash_alg: HashAlgorithm,
         count: u8,
     ) -> Self {
@@ -247,14 +247,14 @@ impl StringToKey {
     /// use pgp::types::StringToKey;
     ///
     /// // First (high memory = 2 GiB) recommended parameter choice
-    /// let s2k = StringToKey::new_argon2(rand::thread_rng(), 1, 4, 21);
+    /// let s2k = StringToKey::new_argon2(&mut rand::rng(), 1, 4, 21);
     /// // Second (low memory = 64 MiB) recommended parameter choice
-    /// let s2k = StringToKey::new_argon2(rand::thread_rng(), 3, 4, 16);
+    /// let s2k = StringToKey::new_argon2(&mut rand::rng(), 3, 4, 16);
     /// ```
     ///
     /// - [RFC 9106 &sect; 4.5 - Argon2 Parameter Choice](https://www.rfc-editor.org/rfc/rfc9106#section-4-5)
     /// - [RFC 9580 &sect; 3.7.1.4 - Argon2 S2K Specifier Type 4](https://www.rfc-editor.org/rfc/rfc9580#section-3.7.1.4)
-    pub fn new_argon2<R: CryptoRng + Rng>(mut rng: R, t: u8, p: u8, m_enc: u8) -> Self {
+    pub fn new_argon2<R: CryptoRng + ?Sized>(rng: &mut R, t: u8, p: u8, m_enc: u8) -> Self {
         let mut salt = [0u8; 16];
         rng.fill(&mut salt[..]);
 
@@ -583,12 +583,12 @@ impl Serialize for StringToKey {
 
 #[cfg(test)]
 mod tests {
+    use chacha20::ChaCha8Rng;
     use proptest::prelude::*;
     use rand::{
-        distributions::{Alphanumeric, DistString},
+        distr::{Alphanumeric, SampleString},
         SeedableRng,
     };
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -115,23 +115,23 @@ impl<A: hash::Hasher, B: io::Write> io::Write for TeeWriter<'_, A, B> {
 #[cfg(test)]
 pub(crate) mod test {
     use bytes::{Buf, Bytes};
-    use rand::Rng;
+    use rand::{Rng, RngExt};
 
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                             abcdefghijklmnopqrstuvwxyz\
                             0123456789)(*&^%$#@!~\r\n .,-!?\t";
 
-    pub(crate) fn random_string(rng: &mut impl Rng, size: usize) -> String {
+    pub(crate) fn random_string<R: Rng + ?Sized>(rng: &mut R, size: usize) -> String {
         (0..size)
             .map(|_| {
-                let idx = rng.gen_range(0..CHARSET.len());
+                let idx = rng.random_range(0..CHARSET.len());
                 CHARSET[idx] as char
             })
             .collect()
     }
 
-    pub(crate) fn random_utf8_string(rng: &mut impl Rng, size: usize) -> String {
-        (0..size).map(|_| rng.r#gen::<char>()).collect()
+    pub(crate) fn random_utf8_string<R: Rng + ?Sized>(rng: &mut R, size: usize) -> String {
+        (0..size).map(|_| rng.random::<char>()).collect()
     }
 
     #[derive(Debug)]
@@ -155,7 +155,7 @@ pub(crate) mod test {
                 return Ok(0);
             }
             let max = buf.len().min(self.source.remaining());
-            let to_write: usize = self.rng.gen_range(1..=max);
+            let to_write: usize = self.rng.random_range(1..=max);
 
             self.source.copy_to_slice(&mut buf[..to_write]);
             Ok(to_write)

--- a/tests/backward-compat.rs
+++ b/tests/backward-compat.rs
@@ -1,5 +1,5 @@
+use chacha20::ChaCha20Rng;
 use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
 
 // Tests that check for backward compatibility with older versions of rpgp
 
@@ -64,7 +64,7 @@ fn encrypt_rpgp_cur(msg: &'static [u8], keyfile: &str) -> String {
         crypto::sym::SymmetricKeyAlgorithm,
     };
 
-    let mut rng = ChaChaRng::from_seed([0u8; 32]);
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
     let (ssk, _headers) =
         pgp::composed::SignedSecretKey::from_armor_single(std::fs::File::open(keyfile).unwrap())

--- a/tests/forwarding.rs
+++ b/tests/forwarding.rs
@@ -6,6 +6,7 @@
 
 use std::io::BufReader;
 
+use chacha20::ChaCha8Rng;
 use pgp::{
     armor::{BlockType, Dearmor},
     composed::{
@@ -22,7 +23,6 @@ use pgp::{
     },
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 const RECIPIENT_KEY: &str = "-----BEGIN PGP PRIVATE KEY BLOCK-----
 

--- a/tests/hsm-test.rs
+++ b/tests/hsm-test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 use std::{fmt::Debug, fs::File};
 
+use chacha20::ChaCha8Rng;
 use p256::pkcs8::DecodePrivateKey;
 use pgp::{
     adapter::{EcdsaSigner, RsaSigner},
@@ -16,7 +17,6 @@ use pgp::{
     },
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Clone)]
 pub struct FakeHsm {
@@ -573,7 +573,7 @@ fn ecdsa_signed_public_key() {
     );
 
     let signed_public_key = SignedPublicKey::bind_with_signing_key(
-        rand::thread_rng(),
+        &mut rand::rng(),
         &signer,
         signer.public_key().clone(),
         details,
@@ -656,7 +656,7 @@ fn ecdsa_signed_public_key_with_signing_subkey() {
     };
 
     let signed_public_key = SignedPublicKey::bind_with_signing_key(
-        rand::thread_rng(),
+        &mut rand::rng(),
         &signer,
         signer.public_key().clone(),
         details,

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -8,7 +8,7 @@ extern crate smallvec;
 use std::{fs::File, io::Read, path::Path};
 
 use buffer_redux::BufReader;
-use num_traits::ToPrimitive;
+use chacha20::ChaCha20Rng;
 use pgp::{
     armor,
     composed::{
@@ -32,7 +32,6 @@ use pgp::{
     },
 };
 use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
 use rsa::traits::PublicKeyParts;
 use testresult::TestResult;
 
@@ -345,7 +344,7 @@ fn test_parse_details() {
     match pk.public_params() {
         PublicParams::RSA(public_params) => {
             assert_eq!(Mpi::from(public_params.key.n().clone()), primary_n);
-            assert_eq!(public_params.key.e().to_u64().unwrap(), 0x0001_0001);
+            assert_eq!(public_params.key.e(), &rsa::BoxedUint::from(0x0001_0001u64));
         }
         _ => panic!("wrong public params: {:?}", pk.public_params()),
     }
@@ -1287,7 +1286,7 @@ fn test_invalid() {
 fn test_locked_key() {
     let p = Path::new("./tests/key-with-password-123.asc");
     let mut file = read_file(p.to_path_buf());
-    let mut rng = ChaChaRng::from_seed([0u8; 32]);
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
     let mut buf = vec![];
     file.read_to_end(&mut buf).unwrap();
@@ -1508,7 +1507,7 @@ fn test_short_ed25519() -> TestResult {
     assert_eq!(secret.as_bytes().len(), 32);
 
     let sig = DetachedSignature::sign_binary_data(
-        rand::thread_rng(),
+        &mut rand::rng(),
         &pkey.primary_key,
         &Password::empty(),
         HashAlgorithm::Sha256,
@@ -1541,10 +1540,13 @@ fn test_non_standard_rsa_modulus() -> TestResult {
     };
 
     // 257 in big-endian bytes
-    assert_eq!(public.key.e().to_bytes_be(), [1, 1]);
+    assert_eq!(
+        public.key.e().to_be_bytes_trimmed_vartime(),
+        vec![1, 1].into_boxed_slice()
+    );
 
     let sig = DetachedSignature::sign_binary_data(
-        rand::thread_rng(),
+        &mut rand::rng(),
         &pkey.primary_key,
         &Password::empty(),
         HashAlgorithm::Sha256,

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -153,31 +153,31 @@ parse_dumps!(
     (
         test_parse_dumps_0,
         0,
-        17_711,
+        17_710,
         // Hash::Other(4)
         0,
-        3282,
+        3283,
         20_993
     ),
     (
         test_parse_dumps_1,
         1,
-        17_561,
+        17_560,
         // - Hash::Other(4)
         // - Elgamal verify
         6,
-        3429,
+        3430,
         20_996
     ),
     (
         test_parse_dumps_2,
         2,
-        17_586,
+        17_585,
         // - Hash::Other(4)
         // - Hash::Other(5)
         // - Elgamal verify
         3,
-        3402,
+        3403,
         20_991
     ),
     (
@@ -212,19 +212,19 @@ parse_dumps!(
     (
         test_parse_dumps_6,
         6,
-        17_696,
+        17_695,
         // - Elgamal verify
         1,
-        3300,
+        3301,
         20_997
     ),
     (
         test_parse_dumps_7,
         7,
-        17_716,
+        17_715,
         // - Elgamal verify
         3,
-        3287,
+        3288,
         21_006
     ),
     (

--- a/tests/large_rsa.rs
+++ b/tests/large_rsa.rs
@@ -1,6 +1,7 @@
 /// Check that we can use an RSA 8k key for encrypt/decrypt and sign/verify
 #[test]
-fn test_rsa_8192() {
+fn test_large_rsa() {
+    use chacha20::ChaCha8Rng;
     use pgp::{
         composed::{
             Deserializable, DetachedSignature, Message, MessageBuilder, SignedPublicKey,
@@ -10,7 +11,6 @@ fn test_rsa_8192() {
         types::Password,
     };
     use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     let mut rng = ChaCha8Rng::seed_from_u64(0);
 

--- a/tests/message_test.rs
+++ b/tests/message_test.rs
@@ -11,6 +11,7 @@ extern crate log;
 
 use std::{collections::VecDeque, fs::File, io::BufReader};
 
+use chacha20::ChaCha8Rng;
 use pgp::{
     composed::{
         CleartextSignedMessage, Deserializable, DetachedSignature, KeyType, Message,
@@ -22,7 +23,6 @@ use pgp::{
     types::{KeyDetails, KeyId, Password},
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/tests/pqc.rs
+++ b/tests/pqc.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "pqc")]
+use chacha20::ChaCha8Rng;
 use pgp::{
     composed::{
         Deserializable, DetachedSignature, EncryptionCaps, KeyType, Message, MessageBuilder,
@@ -7,8 +8,7 @@ use pgp::{
     crypto::{hash::HashAlgorithm, public_key::PublicKeyAlgorithm, sym::SymmetricKeyAlgorithm},
     types::{KeyDetails, KeyVersion, Password},
 };
-use rand::{CryptoRng, RngCore, SeedableRng};
-use rand_chacha::ChaCha8Rng;
+use rand::{CryptoRng, SeedableRng};
 use smallvec::smallvec;
 use testresult::TestResult;
 
@@ -211,7 +211,7 @@ fn test_a_2_4_signed_encrypted() -> TestResult {
     .test()
 }
 
-fn gen_key<R: RngCore + CryptoRng>(mut rng: R) -> TestResult<SignedSecretKey> {
+fn gen_key<R: CryptoRng + ?Sized>(rng: &mut R) -> TestResult<SignedSecretKey> {
     let key_params = SecretKeyParamsBuilder::default()
         .version(KeyVersion::V6)
         .key_type(KeyType::Ed448)
@@ -237,7 +237,7 @@ fn gen_key<R: RngCore + CryptoRng>(mut rng: R) -> TestResult<SignedSecretKey> {
         .unwrap();
 
     let signed_key = key_params
-        .generate(&mut rng)
+        .generate(rng)
         .expect("failed to generate secret key");
 
     signed_key.verify_bindings()?;

--- a/tests/rfc9580.rs
+++ b/tests/rfc9580.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 
+use chacha20::ChaCha8Rng;
 use pgp::{
     composed::{
         CleartextSignedMessage, EncryptionCaps, KeyType, Message, MessageBuilder,
@@ -13,7 +14,6 @@ use pgp::{
     types::{KeyDetails, KeyVersion},
 };
 use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 const MSG: &str = "hello world\n";
 

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -198,7 +198,7 @@ fn rpg_021_signed_secret_key_encrypt_panic1() {
     let dummy_plaintext = vec![0u8; 128];
 
     // note, this is non-deterministic, but does not matter for reproduction
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let key = pgp::composed::SignedSecretKey::from_bytes(bad_input).unwrap();
 
@@ -233,7 +233,7 @@ fn rpg_021_signed_secret_key_encrypt_panic2() {
     // no particular meaning of this data
     // let dummy_plaintext = vec![0u8; 1];
     // note, this is non-deterministic, but does not matter for reproduction
-    // let mut rng = rand::thread_rng();
+    // let mut rng = rand::rng();
     let key = pgp::composed::SignedSecretKey::from_bytes(bad_input);
     assert!(key.is_err());
     // stricter parsing triggers checks earlier

--- a/tests/seipdv1.rs
+++ b/tests/seipdv1.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 
+use chacha20::ChaCha8Rng;
 use pgp::{
     composed::{
         DecryptionOptions, Edata, Message, MessageBuilder, PlainSessionKey, RawSessionKey, TheRing,
@@ -8,41 +9,38 @@ use pgp::{
     packet::{ProtectedDataConfig, SymEncryptedProtectedDataConfig},
     types::Seipdv1ReadMode,
 };
-use rand::{CryptoRng, Rng, RngCore, SeedableRng};
-use rand_chacha::ChaCha8Rng;
+use rand::{CryptoRng, Rng, SeedableRng};
 use rayon::prelude::*;
 use snafu::AsErrorSource;
 
 const SYM_ALG: SymmetricKeyAlgorithm = SymmetricKeyAlgorithm::AES256;
 
-fn make_seipdv1_msg<RAND>(mut rng: RAND, len: usize) -> (Vec<u8>, RawSessionKey)
+fn make_seipdv1_msg<RAND>(rng: &mut RAND, len: usize) -> (Vec<u8>, RawSessionKey)
 where
-    RAND: CryptoRng + Rng,
+    RAND: CryptoRng + ?Sized,
 {
     let input_data: Vec<u8> = b"hello world".iter().cycle().cloned().take(len).collect();
 
     eprintln!("input len: {}", input_data.len());
 
-    let raw = random_session_key(&mut rng);
+    let raw = random_session_key(rng);
 
     eprintln!("encrypting to session key: {:02x?}", raw.as_ref());
     eprintln!();
 
     let mut builder =
-        MessageBuilder::from_bytes("plaintext.txt", input_data).seipd_v1(&mut rng, SYM_ALG);
+        MessageBuilder::from_bytes("plaintext.txt", input_data).seipd_v1(rng, SYM_ALG);
     builder.set_session_key(raw.clone()).expect("ok");
 
     let mut encrypted_data = Vec::new();
-    builder
-        .to_writer(&mut rng, &mut encrypted_data)
-        .expect("ok");
+    builder.to_writer(rng, &mut encrypted_data).expect("ok");
 
     (encrypted_data, raw)
 }
 
-fn random_session_key<RAND>(mut rng: RAND) -> RawSessionKey
+fn random_session_key<RAND>(rng: &mut RAND) -> RawSessionKey
 where
-    RAND: CryptoRng + Rng,
+    RAND: CryptoRng + ?Sized,
 {
     let mut raw = vec![0u8; SYM_ALG.key_size()];
     rng.fill_bytes(&mut raw);


### PR DESCRIPTION
This is probably a bit early, but this PR bumps the dependencies to use @RustCrypto next set of releases.


Missing releases:
 - [ ] argon2 0.6
 - [x] p521 0.14
 - [x] k256 0.14
 - [ ] rsa 0.10
 - [ ] eax 0.6
 - [ ] ocb3 0.2
 - [ ] ed448-goldilocks 0.14
 - [ ] x448 0.14
 - [ ] slh-dsa 0.2
