### PR TITLE
Upgrade bzip2 to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,22 +246,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
- "bzip2-sys",
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1186,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864a00c8d019e36216b69c2c4ce50b83b7bd966add3cf5ba554ec44f8bebcf5"
+checksum = "775bf80d5878ab7c2b1080b5351a48b2f737d9f6f8b383574eebcc22be0dfccb"
 
 [[package]]
 name = "libc"
@@ -1559,12 +1548,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ snafu = { version = "0.8.5", features = ["rust_1_81"] }
 
 # Compression
 flate2 = { version = "1.1.1", default-features = false, features = ["zlib-rs"] }
-bzip2 = { version = "0.5.2", default-features = false, features = ["libbz2-rs-sys"], optional = true }
+bzip2 = { version = "0.6.0", optional = true }
 
 # Crypto
 aes = "0.8.4"


### PR DESCRIPTION
This release makes libbz2-rs-sys the default implementation, so there is no need to enable it manually.