### PR TITLE
feat: add EcdsaPublicParams::curve and is_supported

### DIFF
--- a/src/types/params/public/ecdh.rs
+++ b/src/types/params/public/ecdh.rs
@@ -185,10 +185,15 @@ impl Serialize for EcdhPublicParams {
 }
 
 impl EcdhPublicParams {
+    /// Is this key based on a curve that we know how to parse?
+    ///
+    /// Unsupported curves are modeled as [`Self::Unsupported`].
+    /// Key packets that use such curves are handled as opaque blobs.
     pub fn is_supported(&self) -> bool {
         !matches!(self, Self::Unsupported { .. })
     }
 
+    /// Get the `ECCCurve` that this key is based on
     pub fn curve(&self) -> ECCCurve {
         match self {
             Self::Curve25519 { .. } => ECCCurve::Curve25519,

--- a/src/types/params/public/ecdsa.rs
+++ b/src/types/params/public/ecdsa.rs
@@ -40,10 +40,15 @@ pub enum EcdsaPublicParams {
 }
 
 impl EcdsaPublicParams {
+    /// Is this key based on a curve that we know how to parse?
+    ///
+    /// Unsupported curves are modeled as [`Self::Unsupported`].
+    /// Key packets that use such curves are handled as opaque blobs.
     pub fn is_supported(&self) -> bool {
         !matches!(self, Self::Unsupported { .. })
     }
 
+    /// Get the `ECCCurve` that this key is based on
     pub fn curve(&self) -> ECCCurve {
         match self {
             Self::P256 { .. } => ECCCurve::P256,

--- a/src/types/params/public/ecdsa.rs
+++ b/src/types/params/public/ecdsa.rs
@@ -40,6 +40,20 @@ pub enum EcdsaPublicParams {
 }
 
 impl EcdsaPublicParams {
+    pub fn is_supported(&self) -> bool {
+        !matches!(self, Self::Unsupported { .. })
+    }
+
+    pub fn curve(&self) -> ECCCurve {
+        match self {
+            Self::P256 { .. } => ECCCurve::P256,
+            Self::P384 { .. } => ECCCurve::P384,
+            Self::P521 { .. } => ECCCurve::P521,
+            Self::Secp256k1 { .. } => ECCCurve::Secp256k1,
+            Self::Unsupported { curve, .. } => curve.clone(),
+        }
+    }
+
     /// Ref: <https://www.rfc-editor.org/rfc/rfc9580.html#name-algorithm-specific-part-for-ec>
     pub fn try_from_reader<B: BufRead>(mut i: B, len: Option<usize>) -> Result<Self> {
         // a one-octet size of the following field


### PR DESCRIPTION
This aligns the EcdsaPublicParams API with EcdhPublicParams