### PR TITLE
signer: expose the public key

### DIFF
--- a/src/adapter/ecdsa.rs
+++ b/src/adapter/ecdsa.rs
@@ -80,6 +80,11 @@ where
             _signature: PhantomData,
         })
     }
+
+    /// Return the public key used by the signer
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
 }
 
 impl<C, T> Keypair for EcdsaSigner<T, C>

--- a/src/adapter/rsa.rs
+++ b/src/adapter/rsa.rs
@@ -63,6 +63,11 @@ where
             _digest: PhantomData,
         })
     }
+
+    /// Return the public key
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
 }
 
 impl<D, T> RsaSigner<T, D>


### PR DESCRIPTION
This is useful for building a `pgp::composed::SignedPublicKey` from an HSM-backed signer.

```rust
    let pgp_signer = pgp::adapter::RsaSigner::new(sync_signer, KeyVersion::V4, chrono::Utc::now())
        .unwrap();
     let details = pgp::composed::KeyDetails::new(
        Some(user_id),
        Default::default(),
        Default::default(),
        keyflags,
        Default::default(),
        Default::default(),
        Default::default(),
        Default::default(),
        Default::default(),
    );

    let signed_public_key =
        pgp::composed::PublicKey::new(pgp_signer.public_key().clone(), details, vec![])
            .sign(
                &mut rng,
                &pgp_signer,
                pgp_signer.public_key(),
                &Password::empty(),
            )
            .unwrap();
```