### PR TITLE
fix: always produce IssuerFingerprint subpacket for signatures

### DIFF
--- a/src/composed/cleartext.rs
+++ b/src/composed/cleartext.rs
@@ -67,10 +67,10 @@ where {
         R: rand::Rng + rand::CryptoRng,
     {
         let hashed_subpackets = vec![
-            Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
             Subpacket::regular(SubpacketData::SignatureCreationTime(
                 chrono::Utc::now().trunc_subsecs(0),
             ))?,
+            Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
         ];
 
         let mut config = SignatureConfig::from_key(rng, key, SignatureType::Text)?;

--- a/src/composed/signed_key.rs
+++ b/src/composed/signed_key.rs
@@ -82,7 +82,7 @@
 //!         hash_alg: HashAlgorithm::Sha256,
 //!         hashed_subpackets: vec![
 //!             packet::Subpacket::regular(packet::SubpacketData::SignatureCreationTime(now)).unwrap(),
-//!             packet::Subpacket::regular(packet::SubpacketData::Issuer(signing_key.key_id())).unwrap(),
+//!             packet::Subpacket::regular(packet::SubpacketData::IssuerFingerprint(signing_key.fingerprint())).unwrap(),
 //!         ],
 //!         unhashed_subpackets: vec![],
 //!         version_specific: SignatureVersionSpecific::V4,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -51,7 +51,7 @@
 //! let mut sig_cfg = SignatureConfig::v4(packet::SignatureType::Binary, PublicKeyAlgorithm::RSA, HashAlgorithm::Sha256);
 //! sig_cfg.hashed_subpackets = vec![
 //!     packet::Subpacket::regular(packet::SubpacketData::SignatureCreationTime(now)).unwrap(),
-//!     packet::Subpacket::regular(packet::SubpacketData::Issuer(signing_key.key_id())).unwrap(),
+//!     packet::Subpacket::regular(packet::SubpacketData::IssuerFingerprint(signing_key.fingerprint())).unwrap(),
 //! ];
 //!
 //! let signature_packet = sig_cfg

--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -404,9 +404,12 @@ impl PubKeyInner {
         use chrono::SubsecRound;
 
         let mut config = SignatureConfig::from_key(&mut rng, key, sig_type)?;
-        config.hashed_subpackets = vec![Subpacket::regular(SubpacketData::SignatureCreationTime(
-            chrono::Utc::now().trunc_subsecs(0),
-        ))?];
+        config.hashed_subpackets = vec![
+            Subpacket::regular(SubpacketData::SignatureCreationTime(
+                chrono::Utc::now().trunc_subsecs(0),
+            ))?,
+            Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
+        ];
         if key.version() <= KeyVersion::V4 {
             config.unhashed_subpackets =
                 vec![Subpacket::regular(SubpacketData::Issuer(key.key_id()))?];

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -630,9 +630,12 @@ where
     use chrono::SubsecRound;
 
     let mut config = SignatureConfig::from_key(&mut rng, key, sig_typ)?;
-    config.hashed_subpackets = vec![Subpacket::regular(SubpacketData::SignatureCreationTime(
-        chrono::Utc::now().trunc_subsecs(0),
-    ))?];
+    config.hashed_subpackets = vec![
+        Subpacket::regular(SubpacketData::SignatureCreationTime(
+            chrono::Utc::now().trunc_subsecs(0),
+        ))?,
+        Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
+    ];
     if key.version() <= KeyVersion::V4 {
         config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(key.key_id()))?];
     }

--- a/src/packet/user_attribute.rs
+++ b/src/packet/user_attribute.rs
@@ -262,9 +262,12 @@ impl UserAttribute {
             "typ must be a certifying signature type"
         );
 
-        let hashed_subpackets = vec![Subpacket::regular(SubpacketData::SignatureCreationTime(
-            Utc::now().trunc_subsecs(0),
-        ))?];
+        let hashed_subpackets = vec![
+            Subpacket::regular(SubpacketData::SignatureCreationTime(
+                Utc::now().trunc_subsecs(0),
+            ))?,
+            Subpacket::regular(SubpacketData::IssuerFingerprint(signer.fingerprint()))?,
+        ];
 
         let mut config = SignatureConfig::from_key(&mut rng, signer, typ)?;
 

--- a/src/packet/user_id.rs
+++ b/src/packet/user_id.rs
@@ -139,9 +139,12 @@ impl UserId {
             "typ must be a certifying signature type"
         );
 
-        let hashed_subpackets = vec![Subpacket::regular(SubpacketData::SignatureCreationTime(
-            Utc::now().trunc_subsecs(0),
-        ))?];
+        let hashed_subpackets = vec![
+            Subpacket::regular(SubpacketData::SignatureCreationTime(
+                Utc::now().trunc_subsecs(0),
+            ))?,
+            Subpacket::regular(SubpacketData::IssuerFingerprint(signer.fingerprint()))?,
+        ];
 
         let mut config = SignatureConfig::from_key(&mut rng, signer, typ)?;
 


### PR DESCRIPTION
Fixes #605

Historically, signatures have signaled the issuing key with the (Key ID-based) "Issuer" subpacket.
More recently, the (newer and Fingerprint-based) "Issuer Fingerprint" subpacket has been added to OpenPGP.

In RFC 9580, generation of the "Issuer Fingerprint" subpacket is a "SHOULD:

> "The OpenPGP Key fingerprint of the key issuing the signature. This subpacket SHOULD be included in all signatures."

See: https://www.rfc-editor.org/rfc/rfc9580.html#issuer-fingerprint-subpacket