### PR TITLE
fix: if one pass sig metadata doesn't match signature, don't validate

### DIFF
--- a/src/composed/message/parser.rs
+++ b/src/composed/message/parser.rs
@@ -161,12 +161,8 @@ pub(super) fn next(
                 };
 
                 let reader =
-                    SignatureOnePassReader::new(&one_pass_signature, Box::new(inner_message))?;
-                let message = Message::SignedOnePass {
-                    one_pass_signature,
-                    reader,
-                    is_nested,
-                };
+                    SignatureOnePassReader::new(one_pass_signature, Box::new(inner_message))?;
+                let message = Message::SignedOnePass { reader, is_nested };
                 return Ok(Some(message));
             }
             Tag::CompressedData => {


### PR DESCRIPTION
Refuse to validate one pass signed messages if the metadata in the One Pass Signature packet doesn't match the corresponding metadata in the Signature packet.

(Also see this thread for some more discussion of this topic: https://mailarchive.ietf.org/arch/msg/openpgp/RLMBugGhg_c9xT7zmDrkBklRZB8/)