### PR TITLE
chore!: fix unintended visibilities

### DIFF
--- a/src/packet/signature.rs
+++ b/src/packet/signature.rs
@@ -1,7 +1,7 @@
-pub mod config;
-pub mod de;
-pub mod ser;
-pub mod subpacket;
-pub mod types;
+mod config;
+mod de;
+mod ser;
+pub(crate) mod subpacket;
+pub(crate) mod types;
 
 pub use self::{config::*, types::*};


### PR DESCRIPTION
I think the intent is that the types in these submodules are all re-exported directly in `packet` (as they are). This PR drops some accidental duplicate re-exports.