### PR TITLE
chore: bump MSRV to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.85
+        toolchain: 1.88
         target: ${{ matrix.target }}
         override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "email"]
 exclude = ["tests/tests/*"]
 
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
       alt="docs.rs docs" />
   </a>
   <!-- msrv -->
-  <a href="https://img.shields.io/badge/rustc-1.85+-blue.svg?style=flat-square">
-    <img src="https://img.shields.io/badge/rustc-1.85+-blue.svg?style=flat-square"
-      alt="MSRV 1.85" />
+  <a href="https://img.shields.io/badge/rustc-1.88+-blue.svg?style=flat-square">
+    <img src="https://img.shields.io/badge/rustc-1.88+-blue.svg?style=flat-square"
+      alt="MSRV 1.88" />
   </a>
 </div>
 
@@ -188,7 +188,7 @@ See ["Overview of OpenPGP formats and mechanisms"](docs/openpgp.md) for more det
 
 ## Minimum Supported Rust Version (MSRV)
 
-All crates in this repository support Rust 1.85 or higher. In future minimally supported
+All crates in this repository support Rust 1.88 or higher. In future minimally supported
 version of Rust can be changed, but it will be done with a minor version bump.
 
 ## Funding


### PR DESCRIPTION
At least one dependency has upgraded to needing `1.88`