### PR TITLE
cleanup!: drop some high-level semantics functions from the API

### DIFF
--- a/src/composed/signed_key/public.rs
+++ b/src/composed/signed_key/public.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use chrono::{DateTime, Utc};
 use log::warn;
 use rand::{CryptoRng, Rng};
 
@@ -109,12 +108,6 @@ impl SignedPublicKey {
             details,
             public_subkeys,
         }
-    }
-
-    /// Get the public key expiration as a date.
-    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
-        let expiration = self.details.key_expiration_time()?;
-        Some(*self.primary_key.created_at() + expiration)
     }
 
     fn verify_public_subkeys(&self) -> Result<()> {

--- a/src/composed/signed_key/secret.rs
+++ b/src/composed/signed_key/secret.rs
@@ -1,6 +1,5 @@
 use std::{io, ops::Deref};
 
-use chrono::{DateTime, Utc};
 use generic_array::GenericArray;
 use log::{debug, warn};
 use rand::{CryptoRng, Rng};
@@ -108,12 +107,6 @@ impl SignedSecretKey {
             public_subkeys,
             secret_subkeys,
         }
-    }
-
-    /// Get the secret key expiration as a date.
-    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
-        let expiration = self.details.key_expiration_time()?;
-        Some(*self.primary_key.public_key().created_at() + expiration)
     }
 
     fn verify_public_subkeys(&self) -> Result<()> {

--- a/src/composed/signed_key/shared.rs
+++ b/src/composed/signed_key/shared.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use chrono::Duration;
 use log::warn;
 use smallvec::SmallVec;
 use snafu::Snafu;
@@ -58,23 +57,6 @@ impl SignedKeyDetails {
             users,
             user_attributes,
         }
-    }
-
-    /// Get the key expiration time as a duration.
-    ///
-    /// This method finds the signature with the maximum
-    /// `KeyExpirationTime` offset (which should only occur in
-    /// self-signed signatures) and converts it into a duration.
-    /// The function returns `None` if the key has an infinite
-    /// validity.
-    pub fn key_expiration_time(&self) -> Option<Duration> {
-        // Find the maximum key_expiration_time in all signatures of all user ids.
-        self.users
-            .iter()
-            .flat_map(|user| &user.signatures)
-            .filter_map(|sig| sig.key_expiration_time())
-            .max()
-            .cloned()
     }
 
     fn verify_users<P>(&self, key: &P) -> Result<()>


### PR DESCRIPTION
Remove some functions that are out of scope for rPGP's API:

- `SignedKeyDetails::key_expiration_time`
- `SignedPublicKey::expires_at`
- `SignedSecretKey::expires_at`

This functionality can and should be implemented outside of rPGP.

(Note that the removed implementations didn't cover all cases correctly, and were not safe for use in all contexts.)