### PR TITLE
refactor!: Adjust subpacket name "Issuer Key Id", to align with RFC 9580

### DIFF
--- a/src/composed/cleartext.rs
+++ b/src/composed/cleartext.rs
@@ -81,7 +81,7 @@ where {
         // If the version of the issuer is greater than 4, this subpacket MUST NOT be included in
         // the signature.
         if key.version() <= KeyVersion::V4 {
-            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                 key.legacy_key_id(),
             ))?];
         }

--- a/src/composed/key/shared.rs
+++ b/src/composed/key/shared.rs
@@ -134,7 +134,7 @@ impl KeyDetails {
                 .push(Subpacket::regular(SubpacketData::IsPrimary(true))?);
 
             if key.version() <= KeyVersion::V4 {
-                config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+                config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                     key.legacy_key_id(),
                 ))?];
             }
@@ -167,7 +167,7 @@ impl KeyDetails {
 
                     if key.version() <= KeyVersion::V4 {
                         config.unhashed_subpackets = vec![Subpacket::regular(
-                            SubpacketData::Issuer(key.legacy_key_id()),
+                            SubpacketData::IssuerKeyId(key.legacy_key_id()),
                         )?];
                     }
 

--- a/src/composed/message/builder.rs
+++ b/src/composed/message/builder.rs
@@ -130,7 +130,7 @@ pub enum SubpacketConfig {
     ///
     /// This produces two hashed subpackets: `IssuerFingerprint` and `SignatureCreationTime`.
     ///
-    /// In addition, for v4 keys, an `Issuer` subpacket is added to the unhashed area
+    /// In addition, for v4 keys, an `IssuerKeyId` subpacket is added to the unhashed area
     /// (showing the signer's Key ID).
     #[default]
     Default,
@@ -165,7 +165,7 @@ impl SubpacketConfig {
 
                 let mut unhashed = vec![];
                 if signer.version() <= KeyVersion::V4 {
-                    unhashed.push(Subpacket::regular(SubpacketData::Issuer(
+                    unhashed.push(Subpacket::regular(SubpacketData::IssuerKeyId(
                         signer.legacy_key_id(),
                     ))?);
                 }

--- a/src/composed/signature.rs
+++ b/src/composed/signature.rs
@@ -270,7 +270,7 @@ mod tests {
         assert_eq!(cfg.unhashed_subpackets.len(), 1);
 
         assert_eq!(sig.signature.issuer_fingerprint().len(), 1);
-        assert_eq!(sig.signature.issuer().len(), 1);
+        assert_eq!(sig.signature.issuer_key_id().len(), 1);
 
         // differently normalized plaintext should not verify for SignatureType::Binary
         sig.verify(alice.primary_key.public_key(), PLAIN_LF.as_bytes())
@@ -304,7 +304,7 @@ mod tests {
         assert_eq!(cfg.unhashed_subpackets.len(), 1);
 
         assert_eq!(sig.signature.issuer_fingerprint().len(), 1);
-        assert_eq!(sig.signature.issuer().len(), 1);
+        assert_eq!(sig.signature.issuer_key_id().len(), 1);
 
         // differently normalized plaintext should verify as ok for SignatureType::Text
         sig.verify(alice.primary_key.public_key(), PLAIN_LF.as_bytes())

--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -198,7 +198,7 @@ impl PublicSubkey {
         // If the version of the issuer is greater than 4, this subpacket MUST NOT be included in
         // the signature.
         if primary_sec_key.version() <= KeyVersion::V4 {
-            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                 primary_sec_key.legacy_key_id(),
             ))?];
         }
@@ -415,7 +415,7 @@ impl PubKeyInner {
             Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
         ];
         if key.version() <= KeyVersion::V4 {
-            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                 key.legacy_key_id(),
             ))?];
         }

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -179,7 +179,7 @@ impl SecretSubkey {
         // If the version of the issuer is greater than 4, this subpacket MUST NOT be included in
         // the signature.
         if self.version() <= KeyVersion::V4 {
-            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                 self.legacy_key_id(),
             ))?];
         }
@@ -633,7 +633,7 @@ where
         Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint()))?,
     ];
     if key.version() <= KeyVersion::V4 {
-        config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+        config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
             key.legacy_key_id(),
         ))?];
     }

--- a/src/packet/signature/de.rs
+++ b/src/packet/signature/de.rs
@@ -271,7 +271,7 @@ fn subpacket<B: BufRead>(
         KeyExpirationTime => key_expiration(body),
         PreferredSymmetricAlgorithms => pref_sym_alg(body),
         RevocationKey => revocation_key(body),
-        Issuer => issuer(body),
+        IssuerKeyId => issuer(body),
         Notation => notation_data(body),
         PreferredHashAlgorithms => pref_hash_alg(body),
         PreferredCompressionAlgorithms => pref_com_alg(body),
@@ -383,7 +383,7 @@ fn signature_creation_time<B: BufRead>(mut i: B) -> Result<SubpacketData> {
 fn issuer<B: BufRead>(mut i: B) -> Result<SubpacketData> {
     let key_id = i.read_array::<8>().map(KeyId::from)?;
 
-    Ok(SubpacketData::Issuer(key_id))
+    Ok(SubpacketData::IssuerKeyId(key_id))
 }
 
 /// Parse a Key Expiration Time subpacket

--- a/src/packet/signature/subpacket.rs
+++ b/src/packet/signature/subpacket.rs
@@ -29,7 +29,7 @@ pub enum SubpacketType {
     KeyExpirationTime,
     PreferredSymmetricAlgorithms,
     RevocationKey,
-    Issuer,
+    IssuerKeyId,
     Notation,
     PreferredHashAlgorithms,
     PreferredCompressionAlgorithms,
@@ -65,7 +65,7 @@ impl SubpacketType {
             SubpacketType::KeyExpirationTime => 9,
             SubpacketType::PreferredSymmetricAlgorithms => 11,
             SubpacketType::RevocationKey => 12,
-            SubpacketType::Issuer => 16,
+            SubpacketType::IssuerKeyId => 16,
             SubpacketType::Notation => 20,
             SubpacketType::PreferredHashAlgorithms => 21,
             SubpacketType::PreferredCompressionAlgorithms => 22,
@@ -113,7 +113,7 @@ impl SubpacketType {
             9 => SubpacketType::KeyExpirationTime,
             11 => SubpacketType::PreferredSymmetricAlgorithms,
             12 => SubpacketType::RevocationKey,
-            16 => SubpacketType::Issuer,
+            16 => SubpacketType::IssuerKeyId,
             20 => SubpacketType::Notation,
             21 => SubpacketType::PreferredHashAlgorithms,
             22 => SubpacketType::PreferredCompressionAlgorithms,
@@ -274,7 +274,7 @@ pub enum SubpacketData {
     /// When the key is going to expire
     KeyExpirationTime(Duration),
     /// The OpenPGP Key ID of the key issuing the signature.
-    Issuer(KeyId),
+    IssuerKeyId(KeyId),
     /// List of symmetric algorithms that indicate which algorithms the key holder prefers to use.
     /// Renamed to "Preferred Symmetric Ciphers for v1 SEIPD" in RFC 9580
     PreferredSymmetricAlgorithms(SmallVec<[SymmetricKeyAlgorithm; 8]>),

--- a/src/packet/user_attribute.rs
+++ b/src/packet/user_attribute.rs
@@ -272,7 +272,7 @@ impl UserAttribute {
 
         config.hashed_subpackets = hashed_subpackets;
         if signer.version() <= KeyVersion::V4 {
-            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                 signer.legacy_key_id(),
             ))?];
         }

--- a/src/packet/user_id.rs
+++ b/src/packet/user_id.rs
@@ -150,7 +150,7 @@ impl UserId {
 
         config.hashed_subpackets = hashed_subpackets;
         if signer.version() <= KeyVersion::V4 {
-            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::IssuerKeyId(
                 signer.legacy_key_id(),
             ))?];
         }

--- a/tests/hsm-test.rs
+++ b/tests/hsm-test.rs
@@ -475,7 +475,8 @@ fn card_sign() {
                 DateTime::<Utc>::from_timestamp(sig_creation, 0).unwrap(),
             ))
             .unwrap(),
-            packet::Subpacket::regular(packet::SubpacketData::Issuer(hsm.legacy_key_id())).unwrap(),
+            packet::Subpacket::regular(packet::SubpacketData::IssuerKeyId(hsm.legacy_key_id()))
+                .unwrap(),
         ];
 
         let signature = config.sign(&hsm, &"".into(), DATA).unwrap();
@@ -504,7 +505,8 @@ fn ecdsa_signer() {
             DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
         ))
         .unwrap(),
-        packet::Subpacket::regular(packet::SubpacketData::Issuer(signer.legacy_key_id())).unwrap(),
+        packet::Subpacket::regular(packet::SubpacketData::IssuerKeyId(signer.legacy_key_id()))
+            .unwrap(),
     ];
 
     let signature = config.sign(&signer, &Password::empty(), DATA).unwrap();
@@ -533,7 +535,8 @@ fn rsa_signer() {
             DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
         ))
         .unwrap(),
-        packet::Subpacket::regular(packet::SubpacketData::Issuer(signer.legacy_key_id())).unwrap(),
+        packet::Subpacket::regular(packet::SubpacketData::IssuerKeyId(signer.legacy_key_id()))
+            .unwrap(),
     ];
 
     let signature = config.sign(&signer, &Password::empty(), DATA).unwrap();

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -355,7 +355,7 @@ fn test_parse_details() {
     // TODO: examine subkey details
     assert_eq!(key.public_subkeys.len(), 1, "missing subkey");
 
-    let issuer = Subpacket::regular(SubpacketData::Issuer(KeyId::from([
+    let issuer = Subpacket::regular(SubpacketData::IssuerKeyId(KeyId::from([
         0x4C, 0x07, 0x3A, 0xE0, 0xC8, 0x44, 0x5C, 0x0C,
     ])))
     .unwrap();


### PR DESCRIPTION
The subpacket formerly known as "Issuer" has been renamed into "Issuer Key Id" in RFC 9580. This PR adjusts rPGP's naming.