### PR TITLE
fix: use SHA-2 default hash algorithms

### DIFF
--- a/src/types/params/public.rs
+++ b/src/types/params/public.rs
@@ -241,18 +241,18 @@ impl PublicParams {
             PublicParams::ECDSA(EcdsaPublicParams::P384 { .. }) => HashAlgorithm::Sha384,
             PublicParams::ECDSA(EcdsaPublicParams::P521 { .. }) => HashAlgorithm::Sha512,
 
-            PublicParams::Ed448(_) => HashAlgorithm::Sha3_512,
+            PublicParams::Ed448(_) => HashAlgorithm::Sha512,
 
             #[cfg(feature = "draft-pqc")]
-            PublicParams::MlDsa65Ed25519(_) => HashAlgorithm::Sha3_256,
+            PublicParams::MlDsa65Ed25519(_) => HashAlgorithm::Sha256,
             #[cfg(feature = "draft-pqc")]
-            PublicParams::MlDsa87Ed448(_) => HashAlgorithm::Sha3_512,
+            PublicParams::MlDsa87Ed448(_) => HashAlgorithm::Sha512,
             #[cfg(feature = "draft-pqc")]
-            PublicParams::SlhDsaShake128s(_) => HashAlgorithm::Sha3_256,
+            PublicParams::SlhDsaShake128s(_) => HashAlgorithm::Sha256,
             #[cfg(feature = "draft-pqc")]
-            PublicParams::SlhDsaShake128f(_) => HashAlgorithm::Sha3_256,
+            PublicParams::SlhDsaShake128f(_) => HashAlgorithm::Sha256,
             #[cfg(feature = "draft-pqc")]
-            PublicParams::SlhDsaShake256s(_) => HashAlgorithm::Sha3_512,
+            PublicParams::SlhDsaShake256s(_) => HashAlgorithm::Sha512,
 
             // Not actually signing capable
             PublicParams::Elgamal(_)

--- a/tests/key_test.rs
+++ b/tests/key_test.rs
@@ -1434,7 +1434,7 @@ fn test_locked_v6_go() {
             .unwrap();
 
     pkey.unlock(&Password::from("password"), |public, secret| {
-        assert_eq!(public.hash_alg(), HashAlgorithm::Sha3_512);
+        assert_eq!(public.hash_alg(), HashAlgorithm::Sha512);
         assert!(
             matches!(secret, PlainSecretParams::Ed448(_)),
             "{:?}",


### PR DESCRIPTION
Fixes #684 

SHA-2 hash algorithms are in the MUST and SHOULD range, in RFC 9580.
As long as there is no OpenPGP guidance to prefer SHA-3, it seems more defensive to stick to SHA-2.