### PR TITLE
fixup rust 1.92 new warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+// Pending zeroize_derive 1.5.1 release
+// see https://github.com/RustCrypto/utils/pull/1270
+#![allow(unused_assignments)]
 
 //! # Further reading
 //!


### PR DESCRIPTION
Rust 1.92 emits new warnings:
```
warning: value assigned to `curve` is never read
  --> src/crypto/ecdsa.rs:43:9
   |
43 |         curve: ECCCurve,
   |         ^^^^^
   |
   = help: maybe it is overwritten before being read?
   = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default

warning: value assigned to `mode` is never read
  --> src/crypto/ed25519.rs:58:16
   |
58 |     pub(crate) mode: Mode,
   |                ^^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `public` is never read
  --> src/crypto/elgamal.rs:16:5
   |
16 |     public: ElgamalPublicParams,
   |     ^^^^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `packet_header` is never read
  --> src/packet/key/secret.rs:30:5
   |
30 |     packet_header: PacketHeader,
   |     ^^^^^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `details` is never read
  --> src/packet/key/secret.rs:32:5
   |
32 |     details: super::PublicKey,
   |     ^^^^^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `packet_header` is never read
  --> src/packet/key/secret.rs:39:5
   |
39 |     packet_header: PacketHeader,
   |     ^^^^^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `details` is never read
  --> src/packet/key/secret.rs:41:5
   |
41 |     details: super::PublicSubkey,
   |     ^^^^^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `alg` is never read
  --> src/types/params/plain_secret.rs:63:9
   |
63 |         alg: PublicKeyAlgorithm,
   |         ^^^
   |
   = help: maybe it is overwritten before being read?

warning: value assigned to `pub_params` is never read
  --> src/types/params/plain_secret.rs:68:9
   |
68 |         pub_params: Bytes,
   |         ^^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?
```

Those are rooted in `zeroize_derive`. This commit is to be reverted once a release of zeroize_derive 1.5.1 is available.
See: https://github.com/RustCrypto/utils/pull/1270