### PR TITLE
chore: update zeroize_derive to 1.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This fixes unhelpful warnings https://github.com/RustCrypto/utils/pull/1270