### PR TITLE
refactor: move support for large rsa keys into a separate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ bzip2 = ["dep:bzip2"]
 asm = ["dep:sha1-asm", "sha1/asm", "sha2/asm", "md-5/asm"]
 wasm = ["getrandom", "getrandom/js"]
 
+large-rsa = []
 malformed-artifact-compat = []
 
 draft-pqc = ["dep:ml-kem", "dep:ml-dsa", "dep:slh-dsa"]

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ fn main() -> pgp::errors::Result<()> {
 - `bzip2`: Enables bzip2 support
 - `asm`: Enables assembly based optimizations
 - `wasm`: Allows building for wasm
-- `malformed-artifact-compat`: Be lenient towards some types of malformed artifacts (erroneously formed ECDH PKESK; invalidly short first partial body segments), and allow use of very large RSA keys (>8192 bit). Most users will NOT need this feature, should be disabled by default!
+- `large-rsa`: Allow use of very large RSA keys (raises the limit from 8192 to 16384 bit)
+- `malformed-artifact-compat`: Be lenient towards some types of malformed artifacts (erroneously formed ECDH PKESK; invalidly short first partial body segments). Most users will NOT need this feature, should be disabled by default!
 - `draft-pqc`: Enables implementation of draft-ietf-openpgp-pqc-12 (This is unstable and can have breaking changes in patch releases. DO NOT USE IN PRODUCTION!)
 - `draft-wussler-openpgp-forwarding`: Enables support for the formats from [draft-wussler-openpgp-forwarding](https://datatracker.ietf.org/doc/draft-wussler-openpgp-forwarding/), and decryption of forwarded ECDH Curve25519 OpenPGP messages
 

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -25,9 +25,9 @@ use crate::{
 };
 
 /// MAX_KEY_SIZE limits rsa key size while parsing public key packets
-#[cfg(not(feature = "malformed-artifact-compat"))]
+#[cfg(not(feature = "large-rsa"))]
 pub(crate) const MAX_KEY_SIZE: usize = 8192;
-#[cfg(feature = "malformed-artifact-compat")]
+#[cfg(feature = "large-rsa")]
 pub(crate) const MAX_KEY_SIZE: usize = 16384;
 
 /// The MAX_KEY_SIZE_GENERATE limit applies to generating a new SecretKey


### PR DESCRIPTION
Fixes #666 