### PR TITLE
test: cleartext message with "NotDashEscaped" header

### DIFF
--- a/src/composed/cleartext.rs
+++ b/src/composed/cleartext.rs
@@ -742,4 +742,27 @@ mod tests {
 
         msg.verify(&cert).expect("verify");
     }
+
+    #[test]
+    fn test_cleartext_gpg_fail() {
+        // Test parsing of a cleartext message as described in https://gpg.fail/notdash
+        //
+        // GnuPG allows "NotDashEscaped" headers, this test checks that we reject them.
+
+        let _ = pretty_env_logger::try_init();
+
+        let data = std::fs::read_to_string("./tests/unit-tests/csf/gpg.fail-notdash").unwrap();
+
+        let Err(e) = CleartextSignedMessage::from_string(&data) else {
+            panic!("expected error")
+        };
+
+        assert!(e.to_string().contains("cleartext header Error"));
+
+        let Err(e) = Any::from_string(&data) else {
+            panic!("expected error")
+        };
+
+        assert!(e.to_string().contains("armor header Error"));
+    }
 }

--- a/tests/unit-tests/csf/gpg.fail-notdash
+++ b/tests/unit-tests/csf/gpg.fail-notdash
@@ -1,0 +1,12 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+NotDashEscaped: true
+
+whatever
+-----BEGIN PGP SIGNATURE-----
+
+iHUEABYKAB0WIQRlbkxawcw7huU52X40NjWmhZqRdAUCaVZjXAAKCRA0NjWmhZqR
+dJ2lAP9yoyuRx3sxJLhOQwfxDK9p1sb5OfYNUk7xyrJClGBNFwD/ZWinNBKSOnvx
+qm6DBBYt/QxCQNIpHTd/zQ3BqAwUcQM=
+=Wrb4
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
GnuPG allows "NotDashEscaped" headers for CSF messages.
RFC 9580 does not allow them, this test checks that we reject them.