### PR TITLE
Reintroduce `PublicKey::new` and `PublicSubKey::new`

### DIFF
--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -51,6 +51,7 @@ pub struct PublicSubkey {
 }
 
 impl PublicKey {
+    #[doc(hidden)] // must leak for proptest to work
     pub fn from_inner(inner: PubKeyInner) -> Result<Self> {
         let len = inner.write_len();
         let packet_header = PacketHeader::new_fixed(Tag::PublicKey, len.try_into()?);
@@ -68,6 +69,18 @@ impl PublicKey {
     }
 
     /// Create a new `PublicKey` packet from underlying parameters.
+    pub fn new(
+        version: KeyVersion,
+        algorithm: PublicKeyAlgorithm,
+        created_at: Timestamp,
+        expiration: Option<u16>,
+        public_params: PublicParams,
+    ) -> Result<Self> {
+        let inner = PubKeyInner::new(version, algorithm, created_at, expiration, public_params)?;
+        Self::from_inner(inner)
+    }
+
+    /// Create a new `PublicKey` packet from underlying parameters with a custom header.
     pub fn new_with_header(
         packet_header: PacketHeader,
         version: KeyVersion,
@@ -124,6 +137,7 @@ impl EncryptionKey for PublicKey {
 }
 
 impl PublicSubkey {
+    #[doc(hidden)] // must leak for proptest to work
     pub fn from_inner(inner: PubKeyInner) -> Result<Self> {
         let len = inner.write_len();
         let packet_header = PacketHeader::new_fixed(Tag::PublicSubkey, len.try_into()?);
@@ -134,7 +148,10 @@ impl PublicSubkey {
         })
     }
 
-    pub fn from_inner_with_header(packet_header: PacketHeader, inner: PubKeyInner) -> Result<Self> {
+    pub(super) fn from_inner_with_header(
+        packet_header: PacketHeader,
+        inner: PubKeyInner,
+    ) -> Result<Self> {
         Ok(Self {
             packet_header,
             inner,
@@ -142,6 +159,18 @@ impl PublicSubkey {
     }
 
     /// Create a new `PublicSubkey` packet from underlying parameters.
+    pub fn new(
+        version: KeyVersion,
+        algorithm: PublicKeyAlgorithm,
+        created_at: Timestamp,
+        expiration: Option<u16>,
+        public_params: PublicParams,
+    ) -> Result<Self> {
+        let inner = PubKeyInner::new(version, algorithm, created_at, expiration, public_params)?;
+        Self::from_inner(inner)
+    }
+
+    /// Create a new `PublicSubkey` packet from underlying parameters with a custom header.
     pub fn new_with_header(
         packet_header: PacketHeader,
         version: KeyVersion,


### PR DESCRIPTION
To support proptest, commit https://github.com/rpgp/rpgp/commit/17c38b953fca5862d77ceb35fb6016ced57ab67a, released in v0.16.0, removed the `PublicKey::new()` and `PublicSubKey::new()` methods, replacing them with `...::from_inner(PubKeyInner)`, but `PubKeyInner` was made `#[doc(hidden)]`.

This change reintroduces the previous API, the `PublicKey::new()` and `PublicSubKey::new()` methods, to regain the ability to construct `PublicKey` packets from key primitives, introduced in https://github.com/rpgp/rpgp/pull/142 and released in v0.8.0, rather than expose `struct PubKeyInner` and `PubKeyInner::new()` as new API surface.