### PR TITLE
chore(cargo-deny): ignore ml-dsa advisory for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,5 +23,6 @@ license-files = [
 
 [advisories]
 ignore = [
-    "RUSTSEC-2023-0071" # Waiting for upstream fix
+    "RUSTSEC-2023-0071", # Waiting for upstream fix
+    "RUSTSEC-2025-0144"  # Waiting for new Rust Crypto releases
 ]


### PR DESCRIPTION
Updating ml-dsa requires releases of a new set of Rust Crypto releases.