### PR TITLE
api!: mark legacy ECC curves as such

### DIFF
--- a/benches/benchmarks/key.rs
+++ b/benches/benchmarks/key.rs
@@ -34,18 +34,21 @@ fn bench_key(c: &mut Criterion) {
         b.iter(|| black_box(SignedSecretKey::from_armor_single(&bytes[..]).unwrap()));
     });
 
-    g.bench_function("x25519_parse_armored", |b| {
-        let key = build_key(KeyType::Ed25519Legacy, KeyType::ECDH(ECCCurve::Curve25519));
+    g.bench_function("ed25519legacy_ecdh_curve25519legacy_parse_armored", |b| {
+        let key = build_key(
+            KeyType::Ed25519Legacy,
+            KeyType::ECDH(ECCCurve::Curve25519Legacy),
+        );
         let bytes = key.to_armored_bytes(None.into()).unwrap();
 
         b.iter(|| black_box(SignedSecretKey::from_armor_single(&bytes[..]).unwrap()));
     });
 
-    g.bench_function("x25519_generate", |b| {
+    g.bench_function("ed25519legacy_ecdh_curve25519legacy_generate", |b| {
         b.iter(|| {
             black_box(build_key(
                 KeyType::Ed25519Legacy,
-                KeyType::ECDH(ECCCurve::Curve25519),
+                KeyType::ECDH(ECCCurve::Curve25519Legacy),
             ))
         })
     });

--- a/benches/benchmarks/message.rs
+++ b/benches/benchmarks/message.rs
@@ -126,7 +126,7 @@ fn bench_message(c: &mut Criterion) {
     for (kt1, kt2, sym, asym_name, sym_name) in [
         (
             KeyType::Ed25519Legacy,
-            KeyType::ECDH(ECCCurve::Curve25519),
+            KeyType::ECDH(ECCCurve::Curve25519Legacy),
             SymmetricKeyAlgorithm::AES128,
             "x25519",
             "aes128",

--- a/examples/generate_key.rs
+++ b/examples/generate_key.rs
@@ -16,11 +16,11 @@ use rand::thread_rng;
 fn main() {
     // Generate a new OpenPGP private key (TSK)
     let secret_key = keygen(
-        KeyType::Ed25519Legacy,              // primary
-        KeyType::Ed25519Legacy,              // signing subkey
-        KeyType::ECDH(ECCCurve::Curve25519), // encryption subkey
-        KeyType::Ed25519Legacy,              // authentication subkey
-        "John Doe <jdoe@example.com>",       // user id
+        KeyType::Ed25519Legacy,                    // primary
+        KeyType::Ed25519Legacy,                    // signing subkey
+        KeyType::ECDH(ECCCurve::Curve25519Legacy), // encryption subkey
+        KeyType::Ed25519Legacy,                    // authentication subkey
+        "John Doe <jdoe@example.com>",             // user id
     )
     .expect("failed during keygen");
 

--- a/src/composed.rs
+++ b/src/composed.rs
@@ -51,7 +51,7 @@
 //!     .preferred_hash_algorithms(smallvec![HashAlgorithm::Sha256,])
 //!     .preferred_compression_algorithms(smallvec![])
 //!     .subkeys(vec![SubkeyParamsBuilder::default()
-//!         .key_type(KeyType::ECDH(ECCCurve::Curve25519))
+//!         .key_type(KeyType::ECDH(ECCCurve::Curve25519Legacy))
 //!         .can_encrypt(EncryptionCaps::All)
 //!         .build()
 //!         .expect("Must be able to create subkey")]);

--- a/src/composed/key/builder.rs
+++ b/src/composed/key/builder.rs
@@ -828,7 +828,7 @@ mod tests {
             ])
             .subkey(
                 SubkeyParamsBuilder::default()
-                    .key_type(KeyType::ECDH(ECCCurve::Curve25519))
+                    .key_type(KeyType::ECDH(ECCCurve::Curve25519Legacy))
                     .can_encrypt(EncryptionCaps::All)
                     .passphrase(None)
                     .build()
@@ -1113,8 +1113,8 @@ mod tests {
             gen_ecdsa_ecdh(
                 &mut rng,
                 ECCCurve::Secp256k1,
-                ECCCurve::Curve25519, // we don't currently support ECDH over Secp256k1
-                KeyVersion::V4,       // use of secp256k1 isn't specified in RFC 9580
+                ECCCurve::Curve25519Legacy, // we don't currently support ECDH over Secp256k1
+                KeyVersion::V4,             // use of secp256k1 isn't specified in RFC 9580
             );
         }
     }
@@ -1145,7 +1145,7 @@ mod tests {
             ])
             .subkey(
                 SubkeyParamsBuilder::default()
-                    .key_type(KeyType::ECDH(ECCCurve::Curve25519))
+                    .key_type(KeyType::ECDH(ECCCurve::Curve25519Legacy))
                     .can_encrypt(EncryptionCaps::All)
                     .passphrase(None)
                     .build()

--- a/src/crypto/ecc_curve.rs
+++ b/src/crypto/ecc_curve.rs
@@ -5,16 +5,31 @@ use crate::{
     errors::unsupported_err,
 };
 
+/// ECC Curves.
+///
+/// Standard curves are defined in <https://www.rfc-editor.org/rfc/rfc9580.html#name-ecc-curves-for-openpgp>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum ECCCurve {
-    Curve25519,
-    Ed25519,
+    /// Curve25519Legacy ("1.3.6.1.4.1.3029.1.5.1") curve.
+    ///
+    /// For modern applications you may want to use [`crate::composed::KeyType::X25519`] instead of ECDH with this curve.
+    Curve25519Legacy,
+    /// Ed25519Legacy ("1.3.6.1.4.1.11591.15.1") curve.
+    ///
+    /// For modern applications you may want to use [`crate::composed::KeyType::Ed25519`].
+    Ed25519Legacy,
+    /// NIST P-256 ("1.2.840.10045.3.1.7") curve.
     P256,
+    /// NIST P-384 ("1.3.132.0.34") curve.
     P384,
+    /// NIST P-521 ("1.3.132.0.35") curve.
     P521,
+    /// brainpoolP256r1 ("1.3.36.3.3.2.8.1.1.7") curve.
     BrainpoolP256r1,
+    /// brainpoolP384r1 ("1.3.36.3.3.2.8.1.1.11") curve.
     BrainpoolP384r1,
+    /// brainpoolP512r1 ("1.3.36.3.3.2.8.1.1.13") curve.
     BrainpoolP512r1,
     Secp256k1,
     #[cfg_attr(test, proptest(skip))]
@@ -25,8 +40,8 @@ impl ECCCurve {
     /// Standard name
     pub fn name(&self) -> &str {
         match self {
-            ECCCurve::Curve25519 => "Curve25519",
-            ECCCurve::Ed25519 => "Ed25519",
+            ECCCurve::Curve25519Legacy => "Curve25519Legacy",
+            ECCCurve::Ed25519Legacy => "Ed25519Legacy",
             ECCCurve::P256 => "NIST P-256",
             ECCCurve::P384 => "NIST P-384",
             ECCCurve::P521 => "NIST P-521",
@@ -41,8 +56,8 @@ impl ECCCurve {
     /// IETF formatted OID
     pub fn oid_str(&self) -> String {
         match self {
-            ECCCurve::Curve25519 => "1.3.6.1.4.1.3029.1.5.1".into(),
-            ECCCurve::Ed25519 => "1.3.6.1.4.1.11591.15.1".into(),
+            ECCCurve::Curve25519Legacy => "1.3.6.1.4.1.3029.1.5.1".into(),
+            ECCCurve::Ed25519Legacy => "1.3.6.1.4.1.11591.15.1".into(),
             ECCCurve::P256 => "1.2.840.10045.3.1.7".into(),
             ECCCurve::P384 => "1.3.132.0.34".into(),
             ECCCurve::P521 => "1.3.132.0.35".into(),
@@ -57,8 +72,8 @@ impl ECCCurve {
     /// Nominal bit length of the curve
     pub fn nbits(&self) -> u16 {
         match self {
-            ECCCurve::Curve25519 => 255,
-            ECCCurve::Ed25519 => 255,
+            ECCCurve::Curve25519Legacy => 255,
+            ECCCurve::Ed25519Legacy => 255,
             ECCCurve::P256 => 256,
             ECCCurve::P384 => 384,
             ECCCurve::P521 => 521,
@@ -73,8 +88,8 @@ impl ECCCurve {
     /// Length of secret key in bytes
     pub const fn secret_key_length(&self) -> usize {
         match self {
-            ECCCurve::Curve25519 => 32,
-            ECCCurve::Ed25519 => 32,
+            ECCCurve::Curve25519Legacy => 32,
+            ECCCurve::Ed25519Legacy => 32,
             ECCCurve::P256 => 32,
             ECCCurve::P384 => 48,
             ECCCurve::P521 => 66,
@@ -89,8 +104,8 @@ impl ECCCurve {
     /// Alternative name of the curve
     pub fn alias(&self) -> Option<&str> {
         match self {
-            ECCCurve::Curve25519 => Some("cv25519"),
-            ECCCurve::Ed25519 => Some("ed25519"),
+            ECCCurve::Curve25519Legacy => Some("cv25519"),
+            ECCCurve::Ed25519Legacy => Some("ed25519"),
             ECCCurve::P256 => Some("nistp256"),
             ECCCurve::P384 => Some("nistp384"),
             ECCCurve::P521 => Some("nistp521"),
@@ -105,8 +120,8 @@ impl ECCCurve {
     /// Required algo, or None for ECDSA/ECDH
     pub fn pubkey_algo(&self) -> Option<PublicKeyAlgorithm> {
         match self {
-            ECCCurve::Curve25519 => Some(PublicKeyAlgorithm::ECDH),
-            ECCCurve::Ed25519 => Some(PublicKeyAlgorithm::EdDSALegacy),
+            ECCCurve::Curve25519Legacy => Some(PublicKeyAlgorithm::ECDH),
+            ECCCurve::Ed25519Legacy => Some(PublicKeyAlgorithm::EdDSALegacy),
             ECCCurve::P256 => None,
             ECCCurve::P384 => None,
             ECCCurve::P521 => None,
@@ -121,8 +136,8 @@ impl ECCCurve {
     /// Default hash algorithm for this curve
     pub fn hash_algo(&self) -> crate::errors::Result<HashAlgorithm> {
         match self {
-            ECCCurve::Curve25519
-            | ECCCurve::Ed25519
+            ECCCurve::Curve25519Legacy
+            | ECCCurve::Ed25519Legacy
             | ECCCurve::P256
             | ECCCurve::BrainpoolP256r1
             | ECCCurve::Secp256k1 => Ok(HashAlgorithm::Sha256),
@@ -140,8 +155,8 @@ impl ECCCurve {
     /// Default symmetric encryption algorithm for this curve
     pub fn sym_algo(&self) -> crate::errors::Result<SymmetricKeyAlgorithm> {
         match self {
-            ECCCurve::Curve25519
-            | ECCCurve::Ed25519
+            ECCCurve::Curve25519Legacy
+            | ECCCurve::Ed25519Legacy
             | ECCCurve::P256
             | ECCCurve::BrainpoolP256r1
             | ECCCurve::Secp256k1 => Ok(SymmetricKeyAlgorithm::AES128),
@@ -177,11 +192,11 @@ impl ECCCurve {
 }
 /// Get the right curve given an oid.
 pub fn ecc_curve_from_oid(oid: &[u8]) -> Option<ECCCurve> {
-    if ECCCurve::Curve25519.oid().as_slice() == oid {
-        return Some(ECCCurve::Curve25519);
+    if ECCCurve::Curve25519Legacy.oid().as_slice() == oid {
+        return Some(ECCCurve::Curve25519Legacy);
     }
-    if ECCCurve::Ed25519.oid().as_slice() == oid {
-        return Some(ECCCurve::Ed25519);
+    if ECCCurve::Ed25519Legacy.oid().as_slice() == oid {
+        return Some(ECCCurve::Ed25519Legacy);
     }
     if ECCCurve::P256.oid().as_slice() == oid {
         return Some(ECCCurve::P256);
@@ -246,11 +261,11 @@ mod tests {
         assert_eq!(ECCCurve::P384.oid(), vec![0x2B, 0x81, 0x04, 0x00, 0x22]);
         assert_eq!(ECCCurve::P521.oid(), vec![0x2B, 0x81, 0x04, 0x00, 0x23]);
         assert_eq!(
-            ECCCurve::Ed25519.oid(),
+            ECCCurve::Ed25519Legacy.oid(),
             vec![0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01]
         );
         assert_eq!(
-            ECCCurve::Curve25519.oid(),
+            ECCCurve::Curve25519Legacy.oid(),
             vec![0x2B, 0x06, 0x01, 0x04, 0x01, 0x97, 0x55, 0x01, 0x05, 0x01]
         );
         assert_eq!(

--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -20,27 +20,28 @@ const ANON_SENDER: [u8; 20] = [
     0x20, 0x20, 0x20, 0x20,
 ];
 
-/// ECDH Curve25519 secret key
+/// ECDH Curve25519Legacy secret key
 #[derive(Clone, ZeroizeOnDrop, derive_more::Debug)]
-pub struct Curve25519(#[debug("..")] StaticSecret);
+pub struct Curve25519Legacy(#[debug("..")] StaticSecret);
 
-impl From<StaticSecret> for Curve25519 {
+impl From<StaticSecret> for Curve25519Legacy {
     fn from(value: StaticSecret) -> Self {
         Self(value)
     }
 }
 
-impl PartialEq for Curve25519 {
+impl PartialEq for Curve25519Legacy {
     fn eq(&self, other: &Self) -> bool {
         self.0.as_bytes().eq(other.0.as_bytes())
     }
 }
 
-impl Eq for Curve25519 {}
+impl Eq for Curve25519Legacy {}
 
-impl Curve25519 {
+impl Curve25519Legacy {
     pub fn generate<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let mut secret_key_bytes = Zeroizing::new([0u8; ECCCurve::Curve25519.secret_key_length()]);
+        let mut secret_key_bytes =
+            Zeroizing::new([0u8; ECCCurve::Curve25519Legacy.secret_key_length()]);
         rng.fill_bytes(&mut *secret_key_bytes);
 
         // Clamp, as `to_bytes` does not clamp.
@@ -77,8 +78,8 @@ impl Curve25519 {
 #[derive(Clone, PartialEq, Eq, ZeroizeOnDrop, derive_more::Debug)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum SecretKey {
-    /// ECDH with Curve25519
-    Curve25519(Curve25519),
+    /// ECDH with Curve25519Legacy
+    Curve25519Legacy(Curve25519Legacy),
     /// ECDH with Nist P256
     P256 {
         /// The secret point.
@@ -110,7 +111,7 @@ impl From<&SecretKey> for EcdhPublicParams {
         let hash = curve.hash_algo().expect("known algo");
         let alg_sym = curve.sym_algo().expect("known algo");
         match value {
-            SecretKey::Curve25519(key) => Self::Curve25519 {
+            SecretKey::Curve25519Legacy(key) => Self::Curve25519Legacy {
                 p: PublicKey::from(&key.0),
                 hash,
                 alg_sym,
@@ -139,9 +140,9 @@ impl SecretKey {
     /// Generate an ECDH KeyPair.
     pub fn generate<R: Rng + CryptoRng>(mut rng: R, curve: &ECCCurve) -> Result<Self> {
         match curve {
-            ECCCurve::Curve25519 => {
-                let key = Curve25519::generate(rng);
-                Ok(Self::Curve25519(key))
+            ECCCurve::Curve25519Legacy => {
+                let key = Curve25519Legacy::generate(rng);
+                Ok(Self::Curve25519Legacy(key))
             }
             ECCCurve::P256 => {
                 let secret = p256::SecretKey::random(&mut rng);
@@ -161,9 +162,9 @@ impl SecretKey {
 
     pub(crate) fn try_from_mpi(pub_params: &EcdhPublicParams, d: Mpi) -> Result<Self> {
         match pub_params {
-            EcdhPublicParams::Curve25519 { .. } => {
-                let key = Curve25519::try_from_bytes_rev(d.as_ref())?;
-                Ok(SecretKey::Curve25519(key))
+            EcdhPublicParams::Curve25519Legacy { .. } => {
+                let key = Curve25519Legacy::try_from_bytes_rev(d.as_ref())?;
+                Ok(SecretKey::Curve25519Legacy(key))
             }
             EcdhPublicParams::P256 { .. } => {
                 const SIZE: usize = ECCCurve::P256.secret_key_length();
@@ -203,7 +204,7 @@ impl SecretKey {
 
     fn to_mpi(&self) -> Mpi {
         match self {
-            Self::Curve25519(key) => {
+            Self::Curve25519Legacy(key) => {
                 let bytes = key.to_bytes_rev();
 
                 // create scalar and reverse to little endian
@@ -218,7 +219,7 @@ impl SecretKey {
 
     pub fn curve(&self) -> ECCCurve {
         match self {
-            Self::Curve25519 { .. } => ECCCurve::Curve25519,
+            Self::Curve25519Legacy { .. } => ECCCurve::Curve25519Legacy,
             Self::P256 { .. } => ECCCurve::P256,
             Self::P384 { .. } => ECCCurve::P384,
             Self::P521 { .. } => ECCCurve::P521,
@@ -228,7 +229,7 @@ impl SecretKey {
     /// Returns the secret material as raw bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         match self {
-            Self::Curve25519(key) => key.as_bytes().to_vec(),
+            Self::Curve25519Legacy(key) => key.as_bytes().to_vec(),
             Self::P256 { secret, .. } => secret.to_bytes().to_vec(),
             Self::P384 { secret, .. } => secret.to_bytes().to_vec(),
             Self::P521 { secret, .. } => secret.to_bytes().to_vec(),
@@ -274,7 +275,7 @@ impl Decryptor for SecretKey {
         let hash = data.hash;
 
         let shared_secret = match self {
-            SecretKey::Curve25519(key) => {
+            SecretKey::Curve25519Legacy(key) => {
                 ensure_eq!(data.public_point.len(), 33, "invalid public point"); // prefix "0x40" + 32 bytes = 33 bytes
 
                 let their_public = {
@@ -575,7 +576,7 @@ pub fn encrypt<R: CryptoRng + Rng>(
     );
 
     let (encoded_public, shared_secret, hash, alg_sym) = match params {
-        EcdhPublicParams::Curve25519 {
+        EcdhPublicParams::Curve25519Legacy {
             p,
             hash,
             alg_sym,
@@ -589,7 +590,7 @@ pub fn encrypt<R: CryptoRng + Rng>(
 
             let their_public = p;
             let mut our_secret_key_bytes =
-                Zeroizing::new([0u8; ECCCurve::Curve25519.secret_key_length()]);
+                Zeroizing::new([0u8; ECCCurve::Curve25519Legacy.secret_key_length()]);
             rng.fill_bytes(&mut *our_secret_key_bytes);
             let our_secret = StaticSecret::from(*our_secret_key_bytes);
 
@@ -695,7 +696,7 @@ mod tests {
     #[ignore]
     fn test_encrypt_decrypt() {
         for curve in [
-            ECCCurve::Curve25519,
+            ECCCurve::Curve25519Legacy,
             ECCCurve::P256,
             ECCCurve::P384,
             ECCCurve::P521,
@@ -902,7 +903,7 @@ mod tests {
         }
     }
 
-    impl Arbitrary for Curve25519 {
+    impl Arbitrary for Curve25519Legacy {
         type Parameters = ();
         type Strategy = BoxedStrategy<Self>;
 
@@ -910,7 +911,7 @@ mod tests {
             any::<u64>()
                 .prop_map(|seed| {
                     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-                    Curve25519::generate(&mut rng)
+                    Curve25519Legacy::generate(&mut rng)
                 })
                 .boxed()
         }

--- a/src/packet/key/public.rs
+++ b/src/packet/key/public.rs
@@ -286,7 +286,7 @@ impl PubKeyInner {
         if version != KeyVersion::V4 {
             if matches!(
                 public_params,
-                PublicParams::ECDH(EcdhPublicParams::Curve25519 { .. })
+                PublicParams::ECDH(EcdhPublicParams::Curve25519Legacy { .. })
             ) {
                 bail!(
                     "ECDH over Curve25519 is illegal for key version {}",
@@ -465,7 +465,7 @@ pub(crate) fn encrypt<R: rand::CryptoRng + rand::Rng, K: KeyDetails>(
                     // (See https://www.rfoc-editor.org/rfc/rfc9580.html#section-11.5.1-2)
                     let curve = params.curve();
                     match params {
-                        EcdhPublicParams::Curve25519 { hash, alg_sym, .. }
+                        EcdhPublicParams::Curve25519Legacy { hash, alg_sym, .. }
                         | EcdhPublicParams::P256 { hash, alg_sym, .. }
                         | EcdhPublicParams::P521 { hash, alg_sym, .. }
                         | EcdhPublicParams::P384 { hash, alg_sym, .. } => {
@@ -907,7 +907,7 @@ impl VerifyingKey for PubKeyInner {
                 bail!("ML KEM 1024 X448 can not be used for verify operations");
             }
             PublicParams::ECDH(
-                ref params @ EcdhPublicParams::Curve25519 { .. }
+                ref params @ EcdhPublicParams::Curve25519Legacy { .. }
                 | ref params @ EcdhPublicParams::P256 { .. }
                 | ref params @ EcdhPublicParams::P384 { .. }
                 | ref params @ EcdhPublicParams::P521 { .. },

--- a/src/types/params/plain_secret.rs
+++ b/src/types/params/plain_secret.rs
@@ -147,7 +147,7 @@ impl PlainSecretParams {
             (PublicKeyAlgorithm::EdDSALegacy, PublicParams::EdDSALegacy(_pub_params)) => {
                 let secret = Mpi::try_from_reader(i)?;
 
-                const SIZE: usize = ECCCurve::Ed25519.secret_key_length();
+                const SIZE: usize = ECCCurve::Ed25519Legacy.secret_key_length();
                 let secret = pad_key::<SIZE>(secret.as_ref())?;
                 let key = crate::crypto::ed25519::SecretKey::try_from_bytes(
                     secret,
@@ -426,7 +426,7 @@ impl PlainSecretParams {
                 };
 
                 let (hash, alg_sym) = match params {
-                    EcdhPublicParams::Curve25519 { hash, alg_sym, .. } => (hash, alg_sym),
+                    EcdhPublicParams::Curve25519Legacy { hash, alg_sym, .. } => (hash, alg_sym),
                     EcdhPublicParams::P256 { hash, alg_sym, .. } => (hash, alg_sym),
                     EcdhPublicParams::P384 { hash, alg_sym, .. } => (hash, alg_sym),
                     EcdhPublicParams::P521 { hash, alg_sym, .. } => (hash, alg_sym),
@@ -447,7 +447,7 @@ impl PlainSecretParams {
                 let mut fingerprint = recipient_fp.as_bytes(); // normally: the recipient fp
 
                 #[cfg(feature = "draft-wussler-openpgp-forwarding")]
-                if let EcdhPublicParams::Curve25519 {
+                if let EcdhPublicParams::Curve25519Legacy {
                     ecdh_kdf_type:
                         crate::types::EcdhKdfType::Replaced {
                             replacement_fingerprint,

--- a/src/types/params/public/ecdh.rs
+++ b/src/types/params/public/ecdh.rs
@@ -60,7 +60,7 @@ impl EcdhKdfType {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum EcdhPublicParams {
     /// ECDH public parameters for a curve that we know uses Mpi representation
-    Curve25519 {
+    Curve25519Legacy {
         #[cfg_attr(test, proptest(strategy = "tests::ecdh_curve25519_gen()"))]
         p: x25519_dalek::PublicKey,
         hash: HashAlgorithm,
@@ -120,7 +120,7 @@ impl Serialize for EcdhPublicParams {
         writer.write_all(&oid)?;
 
         let tags = match self {
-            Self::Curve25519 {
+            Self::Curve25519Legacy {
                 p,
                 hash,
                 alg_sym,
@@ -189,7 +189,7 @@ impl Serialize for EcdhPublicParams {
         let mut sum = 1; // oid len
 
         match self {
-            Self::Curve25519 {
+            Self::Curve25519Legacy {
                 p,
                 #[cfg(feature = "draft-wussler-openpgp-forwarding")]
                 ecdh_kdf_type,
@@ -262,7 +262,7 @@ impl EcdhPublicParams {
     /// Get the `ECCCurve` that this key is based on
     pub fn curve(&self) -> ECCCurve {
         match self {
-            Self::Curve25519 { .. } => ECCCurve::Curve25519,
+            Self::Curve25519Legacy { .. } => ECCCurve::Curve25519Legacy,
             Self::P256 { .. } => ECCCurve::P256,
             Self::P384 { .. } => ECCCurve::P384,
             Self::P521 { .. } => ECCCurve::P521,
@@ -282,7 +282,7 @@ impl EcdhPublicParams {
         let curve = ecc_curve_from_oid(&curve_raw).ok_or_else(|| format_err!("invalid curve"))?;
 
         match curve {
-            ECCCurve::Curve25519
+            ECCCurve::Curve25519Legacy
             | ECCCurve::P256
             | ECCCurve::P384
             | ECCCurve::P521
@@ -314,7 +314,7 @@ impl EcdhPublicParams {
                     #[cfg(feature = "draft-wussler-openpgp-forwarding")]
                     0xff => {
                         crate::errors::ensure!(
-                            curve == ECCCurve::Curve25519,
+                            curve == ECCCurve::Curve25519Legacy,
                             "unexpected curve for forwardee key {}",
                             curve
                         );
@@ -361,7 +361,7 @@ impl EcdhPublicParams {
         ecdh_kdf_type: EcdhKdfType,
     ) -> Result<Self> {
         match curve {
-            ECCCurve::Curve25519 => {
+            ECCCurve::Curve25519Legacy => {
                 ensure_eq!(p.len(), 33, "invalid public key length");
                 // public part of the ephemeral key (removes 0x40 prefix)
                 let public_key = &p.as_ref()[1..];
@@ -371,7 +371,7 @@ impl EcdhPublicParams {
                 public_key_arr[..].copy_from_slice(public_key);
 
                 let p = x25519_dalek::PublicKey::from(public_key_arr);
-                Ok(EcdhPublicParams::Curve25519 {
+                Ok(EcdhPublicParams::Curve25519Legacy {
                     p,
                     hash,
                     alg_sym,
@@ -408,7 +408,7 @@ pub(super) mod tests {
     proptest::prop_compose! {
         pub fn ecdh_curve25519_gen()(seed: u64) -> x25519_dalek::PublicKey {
             let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-            let mut secret_key_bytes = [0u8; ECCCurve::Curve25519.secret_key_length()];
+            let mut secret_key_bytes = [0u8; 32];
             rng.fill_bytes(&mut secret_key_bytes);
 
             let secret = x25519_dalek::StaticSecret::from(secret_key_bytes);

--- a/src/types/params/public/eddsa_legacy.rs
+++ b/src/types/params/public/eddsa_legacy.rs
@@ -38,7 +38,7 @@ impl EddsaLegacyPublicParams {
 
         // MPI of an EC point representing a public key
         match curve {
-            ECCCurve::Ed25519 => {
+            ECCCurve::Ed25519Legacy => {
                 let q = Mpi::try_from_reader(&mut i)?;
                 ensure_eq!(q.len(), 33, "invalid Q (len)");
                 ensure_eq!(q.as_ref()[0], 0x40, "invalid Q (prefix)");
@@ -61,7 +61,7 @@ impl EddsaLegacyPublicParams {
 
     pub fn curve(&self) -> ECCCurve {
         match self {
-            Self::Ed25519 { .. } => ECCCurve::Ed25519,
+            Self::Ed25519 { .. } => ECCCurve::Ed25519Legacy,
             Self::Unsupported { curve, .. } => curve.clone(),
         }
     }
@@ -71,7 +71,7 @@ impl Serialize for EddsaLegacyPublicParams {
     fn to_writer<W: io::Write>(&self, writer: &mut W) -> Result<()> {
         match self {
             Self::Ed25519 { key } => {
-                let oid = ECCCurve::Ed25519.oid();
+                let oid = ECCCurve::Ed25519Legacy.oid();
                 writer.write_u8(oid.len().try_into()?)?;
                 writer.write_all(&oid)?;
                 let mut mpi = Vec::with_capacity(33);
@@ -94,7 +94,7 @@ impl Serialize for EddsaLegacyPublicParams {
         let mut sum = 0;
         match self {
             Self::Ed25519 { key } => {
-                let oid = ECCCurve::Ed25519.oid();
+                let oid = ECCCurve::Ed25519Legacy.oid();
                 sum += 1;
                 sum += oid.len();
 

--- a/src/types/params/public/ml_kem768_x25519.rs
+++ b/src/types/params/public/ml_kem768_x25519.rs
@@ -50,7 +50,6 @@ mod tests {
     use rand::SeedableRng;
 
     use super::*;
-    use crate::crypto::ecc_curve::ECCCurve;
 
     impl Arbitrary for MlKem768X25519PublicParams {
         type Parameters = ();
@@ -59,7 +58,7 @@ mod tests {
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             fn from_seed(seed: u64) -> MlKem768X25519PublicParams {
                 let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-                let mut secret_key_bytes = [0u8; ECCCurve::Curve25519.secret_key_length()];
+                let mut secret_key_bytes = [0u8; 32];
                 rng.fill_bytes(&mut secret_key_bytes);
 
                 let secret = x25519_dalek::StaticSecret::from(secret_key_bytes);

--- a/tests/forwarding.rs
+++ b/tests/forwarding.rs
@@ -74,7 +74,7 @@ fn test_forwarding_v4() {
         // inspect the internal shape of the forwardee secret key:
 
         // 1. it has the replacement fingerprint parameter in its encryption subkey
-        let PublicParams::ECDH(EcdhPublicParams::Curve25519 { ecdh_kdf_type, .. }) =
+        let PublicParams::ECDH(EcdhPublicParams::Curve25519Legacy { ecdh_kdf_type, .. }) =
             forwardee.secret_subkeys[0].key.public_key().public_params()
         else {
             panic!("expect ecdh")

--- a/tests/hsm-test.rs
+++ b/tests/hsm-test.rs
@@ -177,10 +177,10 @@ impl FakeHsm {
 
                 let ciphertext = public_point.as_ref();
 
-                let _ciphertext = if params.curve() == ECCCurve::Curve25519 {
+                let _ciphertext = if params.curve() == ECCCurve::Curve25519Legacy {
                     assert_eq!(
                         ciphertext[0], 0x40,
-                        "Unexpected shape of Cv25519 encrypted data"
+                        "Unexpected shape of Curve25519Legacy encrypted data"
                     );
 
                     // Strip trailing 0x40
@@ -197,7 +197,7 @@ impl FakeHsm {
                 let shared_secret: [u8; 32] = dec.try_into().expect("must be [u8; 32]");
 
                 let (hash, alg_sym) = match params {
-                    EcdhPublicParams::Curve25519 { hash, alg_sym, .. }
+                    EcdhPublicParams::Curve25519Legacy { hash, alg_sym, .. }
                     | EcdhPublicParams::P256 { hash, alg_sym, .. }
                     | EcdhPublicParams::P384 { hash, alg_sym, .. }
                     | EcdhPublicParams::P521 { hash, alg_sym, .. } => (hash, alg_sym),

--- a/tests/rfc9580.rs
+++ b/tests/rfc9580.rs
@@ -225,7 +225,7 @@ fn rfc9580_legacy_25519_illegal_in_v6() {
     // -- Create a v6 curve 25519 legacy encryption key, expect failure --
     let mut key_params = SecretKeyParamsBuilder::default();
     key_params
-        .key_type(KeyType::ECDH(ECCCurve::Curve25519))
+        .key_type(KeyType::ECDH(ECCCurve::Curve25519Legacy))
         .version(KeyVersion::V6)
         .can_encrypt(EncryptionCaps::All)
         .primary_user_id("Me <me@example.com>".into());


### PR DESCRIPTION
Currently Ed25519Legacy and Curve25519Legacy
curves are named just Ed25519 and Curve25519
in the code and this is not what
<https://www.rfc-editor.org/rfc/rfc9580.html#name-ecc-curves-for-openpgp> does.

It is not clear that KeyType::ECDH(ECCCurve::Curve25519) is using Curve25519Legacy and you want to use KeyType::X25519 instead to avoid legacy formats.
KeyType::Ed25519Legacy is named correctly,
but uses ECCCurve::Ed25519 inside
which should be named ECCCurve::Ed25519Legacy.