### PR TITLE
signer: make the parameter explicitely a prehash

### DIFF
--- a/src/adapter/ecdsa.rs
+++ b/src/adapter/ecdsa.rs
@@ -131,7 +131,7 @@ where
     T: PrehashSigner<ecdsa::Signature<C>>,
     C::Digest: KnownDigest,
 {
-    fn sign(
+    fn sign_prehash(
         &self,
         _key_pw: &Password,
         hash: HashAlgorithm,

--- a/src/adapter/rsa.rs
+++ b/src/adapter/rsa.rs
@@ -113,7 +113,7 @@ where
     T: PrehashSigner<Signature>,
     D: Digest + KnownDigest,
 {
-    fn sign(
+    fn sign_prehash(
         &self,
         _key_pw: &Password,
         hash: HashAlgorithm,

--- a/src/composed/signed_key.rs
+++ b/src/composed/signed_key.rs
@@ -63,7 +63,7 @@
 //!
 //! // creates the cryptographic core of the signature without any metadata
 //! let signature = signing_key
-//!     .sign(&passwd, HashAlgorithm::Sha256, digest)
+//!     .sign_prehash(&passwd, HashAlgorithm::Sha256, digest)
 //!     .expect("Failed to crate signature");
 //!
 //! // the signature can already be verified

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -59,5 +59,14 @@ pub trait Decryptor {
 
 /// Describes keys that can sign data.
 pub trait Signer {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> crate::errors::Result<SignatureBytes>;
+    #[deprecated]
+    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> crate::errors::Result<SignatureBytes> {
+        self.sign_prehash(hash, digest)
+    }
+
+    fn sign_prehash(
+        &self,
+        hash: HashAlgorithm,
+        digest: &[u8],
+    ) -> crate::errors::Result<SignatureBytes>;
 }

--- a/src/crypto/dsa.rs
+++ b/src/crypto/dsa.rs
@@ -85,7 +85,7 @@ impl Serialize for SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash_algorithm: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash_algorithm: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         let signing_key = &self.key;
         let signature = match hash_algorithm {
             HashAlgorithm::Md5 => signing_key.sign_prehashed_rfc6979::<md5::Md5>(digest),
@@ -181,8 +181,9 @@ mod tests {
                 let key = dsa::SigningKey::from_components(params.key.clone(), x.clone()).unwrap();
                 let key = SecretKey { key };
 
-                let SignatureBytes::Mpis(res) =
-                    key.sign(hash_algorithm, &hashed).expect("failed to sign")
+                let SignatureBytes::Mpis(res) = key
+                    .sign_prehash(hash_algorithm, &hashed)
+                    .expect("failed to sign")
                 else {
                     panic!("invalid sig format");
                 };
@@ -316,8 +317,9 @@ mod tests {
                 let key = dsa::SigningKey::from_components(params.key.clone(), x.clone()).unwrap();
                 let key = SecretKey { key };
 
-                let SignatureBytes::Mpis(res) =
-                    key.sign(hash_algorithm, &hashed).expect("failed to sign")
+                let SignatureBytes::Mpis(res) = key
+                    .sign_prehash(hash_algorithm, &hashed)
+                    .expect("failed to sign")
                 else {
                     panic!("invalid sig format");
                 };

--- a/src/crypto/ecdsa.rs
+++ b/src/crypto/ecdsa.rs
@@ -175,7 +175,7 @@ impl Serialize for SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         if let Some(field_size) = self.secret_key_length() {
             // We require that the signing key length is matched by the hash digest length,
             // see https://www.rfc-editor.org/rfc/rfc9580.html#section-5.2.3.2-5

--- a/src/crypto/ed25519.rs
+++ b/src/crypto/ed25519.rs
@@ -114,7 +114,7 @@ impl SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         let Some(digest_size) = hash.digest_size() else {
             bail!("EdDSA signature: invalid hash algorithm: {:?}", hash);
         };

--- a/src/crypto/ed448.rs
+++ b/src/crypto/ed448.rs
@@ -52,7 +52,7 @@ impl SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         let Some(digest_size) = hash.digest_size() else {
             bail!("EdDSA signature: invalid hash algorithm: {:?}", hash);
         };

--- a/src/crypto/ml_dsa65_ed25519.rs
+++ b/src/crypto/ml_dsa65_ed25519.rs
@@ -80,7 +80,7 @@ impl SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         ensure!(
             ![
                 HashAlgorithm::Md5,

--- a/src/crypto/ml_dsa87_ed448.rs
+++ b/src/crypto/ml_dsa87_ed448.rs
@@ -98,7 +98,7 @@ impl Serialize for SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         ensure!(
             ![
                 HashAlgorithm::Md5,

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -153,7 +153,7 @@ impl Decryptor for SecretKey {
 
 impl Signer for SecretKey {
     /// Sign using RSA, with PKCS1v15 padding.
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         let sig = match hash {
             HashAlgorithm::None => return Err(format_err!("none")),
             HashAlgorithm::Md5 => sign_int::<Md5>(self.0.clone(), digest),

--- a/src/crypto/slh_dsa_shake128f.rs
+++ b/src/crypto/slh_dsa_shake128f.rs
@@ -61,7 +61,7 @@ impl SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         ensure!(
             ![
                 HashAlgorithm::Md5,

--- a/src/crypto/slh_dsa_shake128s.rs
+++ b/src/crypto/slh_dsa_shake128s.rs
@@ -61,7 +61,7 @@ impl SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         ensure!(
             ![
                 HashAlgorithm::Md5,

--- a/src/crypto/slh_dsa_shake256s.rs
+++ b/src/crypto/slh_dsa_shake256s.rs
@@ -61,7 +61,7 @@ impl SecretKey {
 }
 
 impl Signer for SecretKey {
-    fn sign(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(&self, hash: HashAlgorithm, digest: &[u8]) -> Result<SignatureBytes> {
         ensure!(
             ![
                 HashAlgorithm::Md5,

--- a/src/packet/key/secret.rs
+++ b/src/packet/key/secret.rs
@@ -288,10 +288,15 @@ impl SecretSubkey {
 }
 
 impl SigningKey for SecretKey {
-    fn sign(&self, key_pw: &Password, hash: HashAlgorithm, data: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(
+        &self,
+        key_pw: &Password,
+        hash: HashAlgorithm,
+        prehash: &[u8],
+    ) -> Result<SignatureBytes> {
         let mut signature: Option<SignatureBytes> = None;
         self.unlock(key_pw, |pub_params, priv_key| {
-            let sig = create_signature(pub_params, priv_key, hash, data)?;
+            let sig = create_signature(pub_params, priv_key, hash, prehash)?;
             signature.replace(sig);
             Ok(())
         })??;
@@ -372,10 +377,15 @@ impl Imprint for SecretSubkey {
 }
 
 impl SigningKey for SecretSubkey {
-    fn sign(&self, key_pw: &Password, hash: HashAlgorithm, data: &[u8]) -> Result<SignatureBytes> {
+    fn sign_prehash(
+        &self,
+        key_pw: &Password,
+        hash: HashAlgorithm,
+        prehash: &[u8],
+    ) -> Result<SignatureBytes> {
         let mut signature: Option<SignatureBytes> = None;
         self.unlock(key_pw, |pub_params, priv_key| {
-            let sig = create_signature(pub_params, priv_key, hash, data)?;
+            let sig = create_signature(pub_params, priv_key, hash, prehash)?;
             signature.replace(sig);
             Ok(())
         })??;
@@ -605,7 +615,7 @@ fn create_signature(
     pub_params: &PublicParams,
     priv_key: &PlainSecretParams,
     hash: HashAlgorithm,
-    data: &[u8],
+    prehash: &[u8],
 ) -> Result<SignatureBytes> {
     use crate::crypto::Signer;
 
@@ -615,19 +625,19 @@ fn create_signature(
             let PublicParams::RSA(_) = pub_params else {
                 bail!("inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::ECDSA(ref priv_key) => {
             let PublicParams::ECDSA(_) = pub_params else {
                 bail!("inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::DSA(ref priv_key) => {
             let PublicParams::DSA(_) = pub_params else {
                 bail!("inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::ECDH(_) => {
             bail!("ECDH can not be used for signing operations")
@@ -650,27 +660,27 @@ fn create_signature(
             let PublicParams::Ed25519(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         #[cfg(feature = "draft-pqc")]
         PlainSecretParams::MlDsa65Ed25519(ref priv_key) => {
             let PublicParams::MlDsa65Ed25519(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         #[cfg(feature = "draft-pqc")]
         PlainSecretParams::MlDsa87Ed448(ref priv_key) => {
             let PublicParams::MlDsa87Ed448(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::Ed448(ref priv_key) => {
             let PublicParams::Ed448(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::Ed25519Legacy(ref priv_key) => {
             match pub_params {
@@ -684,7 +694,7 @@ fn create_signature(
                     bail!("invalid inconsistent key");
                 }
             }
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::Elgamal(_) => {
             unsupported_err!("Elgamal signing");
@@ -694,21 +704,21 @@ fn create_signature(
             let PublicParams::SlhDsaShake128s(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         #[cfg(feature = "draft-pqc")]
         PlainSecretParams::SlhDsaShake128f(ref priv_key) => {
             let PublicParams::SlhDsaShake128f(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         #[cfg(feature = "draft-pqc")]
         PlainSecretParams::SlhDsaShake256s(ref priv_key) => {
             let PublicParams::SlhDsaShake256s(_) = pub_params else {
                 bail!("invalid inconsistent key");
             };
-            priv_key.sign(hash, data)
+            priv_key.sign_prehash(hash, prehash)
         }
         PlainSecretParams::Unknown { alg, .. } => {
             unsupported_err!("{:?} signing", alg);
@@ -787,25 +797,31 @@ mod tests {
             .unwrap();
 
         // signing with a wrong password should fail
-        assert!(alice_sec.sign(&"wrong".into(), hash_algo, DATA).is_err());
+        assert!(alice_sec
+            .sign_prehash(&"wrong".into(), hash_algo, DATA)
+            .is_err());
 
         // signing with the right password should succeed
-        assert!(alice_sec.sign(&"password".into(), hash_algo, DATA).is_ok());
+        assert!(alice_sec
+            .sign_prehash(&"password".into(), hash_algo, DATA)
+            .is_ok());
 
         // remove the password protection
         alice_sec.remove_password(&"password".into()).unwrap();
 
         // signing without a password should succeed now
-        assert!(alice_sec.sign(&"".into(), hash_algo, DATA).is_ok());
+        assert!(alice_sec.sign_prehash(&"".into(), hash_algo, DATA).is_ok());
 
         // set different password protection
         alice_sec.set_password(&mut rng, &"foo".into()).unwrap();
 
         // signing without a password should fail now
-        assert!(alice_sec.sign(&"".into(), hash_algo, DATA).is_err());
+        assert!(alice_sec.sign_prehash(&"".into(), hash_algo, DATA).is_err());
 
         // signing with the right password should succeed
-        assert!(alice_sec.sign(&"foo".into(), hash_algo, DATA).is_ok());
+        assert!(alice_sec
+            .sign_prehash(&"foo".into(), hash_algo, DATA)
+            .is_ok());
 
         // remove the password protection again
         alice_sec.remove_password(&"foo".into()).unwrap();
@@ -820,7 +836,7 @@ mod tests {
 
         // signing with the right password should succeed
         alice_sec
-            .sign(&"bar".into(), hash_algo, DATA)
+            .sign_prehash(&"bar".into(), hash_algo, DATA)
             .expect("failed to sign");
     }
 

--- a/src/packet/signature/config.rs
+++ b/src/packet/signature/config.rs
@@ -334,7 +334,7 @@ impl SignatureConfig {
         let hash = &hasher.finalize()[..];
 
         let signed_hash_value = [hash[0], hash[1]];
-        let signature = signer.sign(signer_pw, self.hash_alg, hash)?;
+        let signature = signer.sign_prehash(signer_pw, self.hash_alg, hash)?;
 
         Signature::from_config(self, signed_hash_value, signature)
     }
@@ -379,7 +379,7 @@ impl SignatureConfig {
 
         let hash = &hasher.finalize()[..];
         let signed_hash_value = [hash[0], hash[1]];
-        let signature = signer.sign(signer_pw, self.hash_alg, hash)?;
+        let signature = signer.sign_prehash(signer_pw, self.hash_alg, hash)?;
 
         Signature::from_config(self, signed_hash_value, signature)
     }
@@ -425,7 +425,7 @@ impl SignatureConfig {
 
         let hash = &hasher.finalize()[..];
         let signed_hash_value = [hash[0], hash[1]];
-        let signature = signer.sign(signer_pw, self.hash_alg, hash)?;
+        let signature = signer.sign_prehash(signer_pw, self.hash_alg, hash)?;
 
         Signature::from_config(self, signed_hash_value, signature)
     }
@@ -464,7 +464,7 @@ impl SignatureConfig {
 
         let hash = &hasher.finalize()[..];
         let signed_hash_value = [hash[0], hash[1]];
-        let signature = signing_key.sign(key_pw, self.hash_alg, hash)?;
+        let signature = signing_key.sign_prehash(key_pw, self.hash_alg, hash)?;
 
         Signature::from_config(self, signed_hash_value, signature)
     }
@@ -786,7 +786,7 @@ impl SignatureHasher {
         let hash = &hasher.finalize()[..];
 
         let signed_hash_value = [hash[0], hash[1]];
-        let signature = key.sign(key_pw, config.hash_alg, hash)?;
+        let signature = key.sign_prehash(key_pw, config.hash_alg, hash)?;
 
         Signature::from_config(config, signed_hash_value, signature)
     }

--- a/src/types/key_traits.rs
+++ b/src/types/key_traits.rs
@@ -138,11 +138,11 @@ impl KeyDetails for Box<&dyn SigningKey> {
 /// Contains private data.
 pub trait SigningKey: KeyDetails {
     /// Create a raw cryptographic signature over `data`
-    fn sign(
+    fn sign_prehash(
         &self,
         key_pw: &Password,
         hash: HashAlgorithm,
-        data: &[u8],
+        prehash: &[u8],
     ) -> Result<crate::types::SignatureBytes>;
 
     /// The recommended hash algorithm to calculate the signature hash digest with,
@@ -151,13 +151,13 @@ pub trait SigningKey: KeyDetails {
 }
 
 impl SigningKey for Box<&dyn SigningKey> {
-    fn sign(
+    fn sign_prehash(
         &self,
         key_pw: &Password,
         hash: HashAlgorithm,
-        data: &[u8],
+        prehash: &[u8],
     ) -> Result<crate::types::SignatureBytes> {
-        (**self).sign(key_pw, hash, data)
+        (**self).sign_prehash(key_pw, hash, prehash)
     }
 
     fn hash_alg(&self) -> HashAlgorithm {

--- a/tests/hsm-test.rs
+++ b/tests/hsm-test.rs
@@ -98,13 +98,13 @@ impl KeyDetails for FakeHsm {
 }
 
 impl SigningKey for FakeHsm {
-    fn sign(
+    fn sign_prehash(
         &self,
         _key_pw: &Password,
         _hash: HashAlgorithm,
-        data: &[u8],
+        prehash: &[u8],
     ) -> pgp::errors::Result<SignatureBytes> {
-        assert_eq!(data, self.sign_data.unwrap().0);
+        assert_eq!(prehash, self.sign_data.unwrap().0);
 
         // XXX: imagine a smartcard producing a signature for `data`, here
 


### PR DESCRIPTION
This is an attempt at making the usage of the slice explicit.

In a followup commit, I'd love to try to adjust the signer APIs to allow for the raw (unhashed) slice to be passed instead. When a private key is held externally (HSM, TPM, ...) the interface may not allow to sign prehashed byte strings.

This is an API breaking change.