### PR TITLE
WIP: add some convenience functionality to Timestamp and Duration

### DIFF
--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -10,6 +10,8 @@ use crate::ser::Serialize;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Default)]
 pub struct Duration(u32);
 
+const SECONDS_PER_DAY: u32 = 24 * 60 * 60;
+
 impl fmt::Debug for Duration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let time: std::time::Duration = (*self).into();
@@ -51,6 +53,11 @@ impl Duration {
     /// Creates a new [`Duration`] from seconds.
     pub fn from_secs(secs: u32) -> Self {
         Self(secs)
+    }
+
+    /// Creates a new [`Duration`] that represents a given number of days.
+    pub fn days(days: u32) -> Self {
+        Self(days * SECONDS_PER_DAY)
     }
 }
 

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -56,7 +56,7 @@ impl Duration {
     }
 
     /// Creates a new [`Duration`] that represents a given number of days.
-    pub fn days(days: u32) -> Self {
+    pub fn from_days(days: u32) -> Self {
         Self(days * SECONDS_PER_DAY)
     }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -6,7 +6,7 @@ use byteorder::BigEndian;
 #[cfg(feature = "wasm")]
 use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::ser::Serialize;
+use crate::{ser::Serialize, types::Duration};
 
 /// Timestamp that refers to a moment in time after the [`UNIX_EPOCH`].
 ///
@@ -23,7 +23,7 @@ impl fmt::Debug for Timestamp {
 
 impl From<Timestamp> for SystemTime {
     fn from(value: Timestamp) -> Self {
-        UNIX_EPOCH + Duration::from_secs(u64::from(value.0))
+        UNIX_EPOCH + std::time::Duration::from_secs(u64::from(value.0))
     }
 }
 
@@ -79,6 +79,13 @@ impl Serialize for Timestamp {
 
     fn write_len(&self) -> usize {
         4
+    }
+}
+
+impl Add<Duration> for Timestamp {
+    type Output = Timestamp;
+    fn add(self, d: Duration) -> Self::Output {
+        Timestamp::from_secs(self.as_secs() + d.as_secs())
     }
 }
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,12 +1,12 @@
-use std::fmt;
 #[cfg(not(feature = "wasm"))]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{fmt, ops::Add};
 
 use byteorder::BigEndian;
 #[cfg(feature = "wasm")]
 use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::{ser::Serialize, types::Duration};
+use crate::ser::Serialize;
 
 /// Timestamp that refers to a moment in time after the [`UNIX_EPOCH`].
 ///
@@ -23,7 +23,7 @@ impl fmt::Debug for Timestamp {
 
 impl From<Timestamp> for SystemTime {
     fn from(value: Timestamp) -> Self {
-        UNIX_EPOCH + std::time::Duration::from_secs(u64::from(value.0))
+        UNIX_EPOCH + Duration::from_secs(u64::from(value.0))
     }
 }
 
@@ -82,9 +82,9 @@ impl Serialize for Timestamp {
     }
 }
 
-impl Add<Duration> for Timestamp {
+impl Add<crate::types::Duration> for Timestamp {
     type Output = Timestamp;
-    fn add(self, d: Duration) -> Self::Output {
+    fn add(self, d: crate::types::Duration) -> Self::Output {
         Timestamp::from_secs(self.as_secs() + d.as_secs())
     }
 }


### PR DESCRIPTION
rPGP's `Timestamp` and `Duration` APIs are currently very minimal.

This PR collects some ergonomics improvements, based on concrete needs in various software that uses rPGP.