### PR TITLE
chore: add rustfmt config that matches CI

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+reorder_imports = true


### PR DESCRIPTION
It seems CI is enforcing this style of formatting, but we don't currently have a config in the project that helps to automatically produce it?