### PR TITLE
ci: add dependency cooldown for dependabot and setup zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
@@ -30,18 +32,19 @@ jobs:
       uses: actions/checkout@master
       with:
         submodules: recursive
+        persist-credentials: false
 
     - name: Checkout submodules
       run: git submodule update --checkout
 
     - name: Install ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: ${{ matrix.rust }}
         override: true
 
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26
       with:
         tool: nextest@0.9.80
 
@@ -95,6 +98,7 @@ jobs:
       uses: actions/checkout@master
       with:
         submodules: recursive
+        persist-credentials: false
 
     - name: Checkout submodules
       run: git submodule update --checkout
@@ -103,7 +107,7 @@ jobs:
       run: rustup default ${{ matrix.rust }}
 
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26
       with:
         tool: nextest@0.9.80
 
@@ -134,12 +138,13 @@ jobs:
       uses: actions/checkout@master
       with:
         submodules: recursive
+        persist-credentials: false
 
     - name: Checkout submodules
       run: git submodule update --checkout
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: 1.88
         target: ${{ matrix.target }}
@@ -165,9 +170,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+      with:
+        persist-credentials: false
 
     - name: Install rust with wasm32-unknown-unknown
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: ${{ matrix.rust }}
         target: wasm32-unknown-unknown
@@ -180,13 +187,13 @@ jobs:
         key: wasm32-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
     - name: check
-      uses: actions-rs/cargo@v1
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: check
         args: --target wasm32-unknown-unknown --no-default-features --features wasm
 
     - name: check - pqc
-      uses: actions-rs/cargo@v1
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: check
         args: --target wasm32-unknown-unknown --no-default-features --features wasm,draft-pqc
@@ -199,11 +206,15 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: mozilla-actions/sccache-action@v0.0.7
-      - uses: taiki-e/install-action@cargo-make
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26
+        with:
+          tool: cargo-make
       - run: cargo make format-check
 
   check_docs:
@@ -211,8 +222,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      with:
+        persist-credentials: false
 
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
           profile: minimal
           toolchain: ${{ env.RUST_NIGHTLY }}
@@ -226,13 +239,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+      with:
+        persist-credentials: false
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
           profile: minimal
           toolchain: ${{ env.RUST_NIGHTLY }}
           override: true
           components: clippy
-    - uses: actions-rs/clippy-check@v1
+    - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-features --all-targets --tests --bins --examples --benches
@@ -241,7 +256,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: codespell-project/actions-codespell@master
+        with:
+          persist-credentials: false
+      - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
 
   cargo_deny:
     timeout-minutes: 30
@@ -249,7 +266,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           arguments: --workspace --all-features
           command: check
@@ -260,8 +279,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+        with:
+          persist-credentials: false
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           profile: minimal
           toolchain: ${{ env.RUST_NIGHTLY }}

--- a/.github/workflows/zizmor-scan.yml
+++ b/.github/workflows/zizmor-scan.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        dependabot/*: ref-pin
+        dtolnay/rust-toolchain: ref-pin


### PR DESCRIPTION
[Zizmor](https://github.com/zizmorcore/zizmor) is a security linter for github actions. Probably most important change is `permissions: {}` which makes sure CI cannot do many things they don't need to like creating releases. If we need to do it, permissions should be explicitly set for the jobs that are meant to create releases.

Also added dependency cooldown for dependabot just because zizmor recommends this. Probably does not hurt, in case some bad dependency update is released and revoked two days later because it is bad.