### PR TITLE
fix: Timestamp::now() panics in WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "tempfile",
  "testresult",
  "twofish",
+ "web-time",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2318,6 +2319,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ ml-dsa = { version = "0.0.4", features = ["zeroize"], optional = true }
 slh-dsa = { version = "0.0.3", optional = true }
 replace_with = "0.1.8"
 
+# WASM helpers
+web-time = { version = "1.1", optional = true }
+
 
 [dev-dependencies]
 glob = "0.3"
@@ -137,7 +140,7 @@ default = ["bzip2"]
 # See README.md for features documentation
 bzip2 = ["dep:bzip2"]
 asm = ["dep:sha1-asm", "sha1/asm", "sha2/asm", "md-5/asm"]
-wasm = ["getrandom", "getrandom/js"]
+wasm = ["getrandom", "getrandom/js", "web-time"]
 
 large-rsa = []
 malformed-artifact-compat = []

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,7 +1,10 @@
-use std::{
-    fmt,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::fmt;
+
+#[cfg(feature = "wasm")]
+use web_time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(not(feature = "wasm"))]
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use byteorder::BigEndian;
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,12 +1,10 @@
 use std::fmt;
-
-#[cfg(feature = "wasm")]
-use web_time::{Duration, SystemTime, UNIX_EPOCH};
-
 #[cfg(not(feature = "wasm"))]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use byteorder::BigEndian;
+#[cfg(feature = "wasm")]
+use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::ser::Serialize;
 


### PR DESCRIPTION
I added `web-time` as a dependency and used it as a drop-in replacement for `std::time` which is incompatible with WASM.

Fixes #783