### PR TITLE
docs: More documentation for Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ Don't see your project here? Please send a PR :)
 use pgp::composed::{Deserializable, Message, SignedPublicKey};
 
 fn main() -> pgp::errors::Result<()> {
-    let (public_key, _headers_public) = SignedPublicKey:: from_armor_file("key.asc")?;
-   
+    let (public_key, _headers_public) = SignedPublicKey::from_armor_file("key.asc")?;
+
     let (mut msg, _headers_msg) = Message::from_armor_file("msg.asc")?;
+    let payload = msg.as_data_string()?;
     if msg.verify(&public_key).is_ok() { // Verify using the primary (NOTE: This is not always the right key!)
         // Signature is correct, print message payload
-        println!("Signed message: {:?}", msg.as_data_string()?);
+        println!("Signed message: {:?}", payload);
     }
-   
+
     Ok(())
 }
 ```

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -153,8 +153,7 @@ impl BufRead for MessageReader<'_> {
 ///
 /// The core of any OpenPGP message is a plaintext payload, encoded as a "Literal Message".
 ///
-/// A Literal Message may be encrypted, cryptographically
-/// signed, and/or compressed.
+/// A Literal Message may be encrypted, cryptographically signed, and/or compressed.
 ///
 /// The OpenPGP message grammar allows arbitrary (and recursive) wrapping of the central
 /// Literal Message in a series of:

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -183,7 +183,14 @@ impl BufRead for MessageReader<'_> {
 /// Callers should consume `Message` as a streaming reader, wherever possible. Depending on the
 /// use case, wrapping `Message` with a limiting reader
 /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
-/// is a good strategy.
+/// is a good strategy.)
+///
+/// Note: If the message still contains unread data after limited reading (as tested e.g. via
+/// `Message::has_buffer_available`), the caller must consider the operation unsuccessful, and
+/// proceed accordingly - e.g. by throwing an error.
+///
+/// In particular, note that signatures over a message cannot be verified with `Message::verify`
+/// if the message has not been fully read (e.g. when using a limited readers)!
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Message<'a> {

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -151,16 +151,39 @@ impl BufRead for MessageReader<'_> {
 
 /// An [OpenPGP message](https://www.rfc-editor.org/rfc/rfc9580.html#name-openpgp-messages)
 ///
-/// Represents one of:
+/// The core of any OpenPGP message is a plaintext payload, encoded as a "Literal Message".
+///
+/// A Literal Message may be encrypted, cryptographically
+/// signed, and/or compressed.
+///
+/// The OpenPGP message grammar allows arbitrary (and recursive) wrapping of the central
+/// Literal Message in a series of:
 ///
 /// - Encrypted Message,
 /// - Signed Message (either one-pass signed or prefixed-signed),
-/// - Compressed Message,
-/// - Literal Message.
+/// - Compressed Message.
 ///
-/// OpenPGP message may consist of multiple layers wrapped around each other (such as for example:
-/// an encrypted message, containing a compressed message, containing a one-pass signed message,
-/// containing a literal message).
+/// (For example: An encrypted message, containing a compressed message, containing a one-pass
+/// signed message, containing a literal message).
+///
+/// This type allows consuming an existing message, and processing its various layers:
+///
+/// If the message contains an encryption layer, then Message attempts to decrypt it,
+/// using material provided with the `decrypt*` function calls.
+///
+/// If the message contains signatures, then these may be verified *after* the message body has
+/// been fully consumed by the caller, using the `verify` function.
+///
+/// Compressed layers can be unwrapped with the `decompress` function.
+///
+/// NOTE: When consuming a message, the output may be arbitrarily large.
+/// A consumer who needs to defend against resource exhaustion should take care to avoid attempting
+/// to allocate more memory than is available in their context.
+///
+/// Callers should consume `Message` as a streaming reader, wherever possible. Depending on the
+/// use case, wrapping `Message` with a limiting reader
+/// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
+/// is a good strategy.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Message<'a> {
@@ -983,6 +1006,14 @@ impl<'a> Message<'a> {
     }
 
     /// Consumes the reader and reads into a vec.
+    ///
+    /// NOTE: The output of this call may be arbitrarily large, and allocate a potentially large
+    /// amount of memory!
+    /// This convenience function is not appropriate for use in environments where "out of memory"
+    /// crashes are unacceptable!
+    ///
+    /// Callers should consider using a limited reader (e.g. via `Read::take`) to safely consume
+    /// message payloads via the `Read` implementation of this type.
     pub fn as_data_vec(&mut self) -> io::Result<Vec<u8>> {
         let mut out = Vec::new();
         self.read_to_end(&mut out)?;
@@ -990,6 +1021,14 @@ impl<'a> Message<'a> {
     }
 
     /// Consumes the reader and reads into a string.
+    ///
+    /// NOTE: The output of this call may be arbitrarily large, and allocate a potentially large
+    /// amount of memory!
+    /// This convenience function is not appropriate for use in environments where "out of memory"
+    /// crashes are unacceptable!
+    ///
+    /// Callers should consider using a limited reader (e.g. via `Read::take`) to safely consume
+    /// message payloads via the `Read` implementation of this type.
     pub fn as_data_string(&mut self) -> io::Result<String> {
         let mut out = String::new();
         self.read_to_string(&mut out)?;

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -176,21 +176,26 @@ impl BufRead for MessageReader<'_> {
 ///
 /// Compressed layers can be unwrapped with the `decompress` function.
 ///
-/// NOTE: When consuming a message, the output may be arbitrarily large.
-/// A consumer who needs to defend against resource exhaustion should take care to avoid attempting
-/// to allocate more memory than is available in their context.
+/// **Message output may be arbitrarily large**
 ///
-/// Callers should consume `Message` as a streaming reader, wherever possible. Depending on the
-/// use case, wrapping `Message` with a limiting reader
+/// When consuming a message, the output may be arbitrarily large.
+/// Applications that consume messages need to deal with this fact, in accordance with their
+/// requirements.
+///
+/// In particular, consumers who need to defend against resource exhaustion must be cautious to
+/// avoid allocating more memory than is available in their context!
+///
+/// Defensive users should consume `Message` as a streaming reader, wherever possible.
+/// Depending on the use case, wrapping `Message` with a limiting reader
 /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
 /// is a good strategy.)
 ///
-/// Note: If the message still contains unread data after limited reading (as tested e.g. via
-/// `Message::has_buffer_available`), the caller must consider the operation unsuccessful, and
+/// Caution: If the message still contains unread data after limited reading (as tested e.g. via
+/// [`Message::has_buffer_available`]), the caller must consider the operation unsuccessful, and
 /// proceed accordingly - e.g. by throwing an error.
 ///
-/// In particular, note that signatures over a message cannot be verified with `Message::verify`
-/// if the message has not been fully read (e.g. when using a limited readers)!
+/// Also note that signatures over a message *can not be verified* with [`Message::verify`]
+/// if the message has not been fully read!
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Message<'a> {
@@ -1021,6 +1026,8 @@ impl<'a> Message<'a> {
     ///
     /// Callers should consider using a limited reader (e.g. via `Read::take`) to safely consume
     /// message payloads via the `Read` implementation of this type.
+    ///
+    /// See the top level [`Message`] documentation for more information!
     pub fn as_data_vec(&mut self) -> io::Result<Vec<u8>> {
         let mut out = Vec::new();
         self.read_to_end(&mut out)?;
@@ -1036,6 +1043,8 @@ impl<'a> Message<'a> {
     ///
     /// Callers should consider using a limited reader (e.g. via `Read::take`) to safely consume
     /// message payloads via the `Read` implementation of this type.
+    ///
+    /// See the top level [`Message`] documentation for more information!
     pub fn as_data_string(&mut self) -> io::Result<String> {
         let mut out = String::new();
         self.read_to_string(&mut out)?;

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -187,8 +187,7 @@ impl BufRead for MessageReader<'_> {
 ///
 /// Defensive users should consume `Message` as a streaming reader, wherever possible.
 /// Depending on the use case, wrapping `Message` with a limiting reader
-/// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
-/// is a good strategy.)
+/// (e.g. via [`std::io::Read::take`] is a good strategy.)
 ///
 /// Caution: If the message still contains unread data after limited reading, the caller must
 /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
@@ -1026,8 +1025,7 @@ impl<'a> Message<'a> {
     ///
     /// Defensive users should consume `Message` as a streaming reader, wherever possible.
     /// Depending on the use case, wrapping `Message` with a limiting reader
-    /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
-    /// is a good strategy.)
+    /// (e.g. via [`std::io::Read::take`] is a good strategy.)
     ///
     /// Caution: If the message still contains unread data after limited reading, the caller must
     /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
@@ -1050,8 +1048,7 @@ impl<'a> Message<'a> {
     ///
     /// Defensive users should consume `Message` as a streaming reader, wherever possible.
     /// Depending on the use case, wrapping `Message` with a limiting reader
-    /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
-    /// is a good strategy.)
+    /// (e.g. via [`std::io::Read::take`] is a good strategy.)
     ///
     /// Caution: If the message still contains unread data after limited reading, the caller must
     /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -191,7 +191,8 @@ impl BufRead for MessageReader<'_> {
 ///
 /// Caution: If the message still contains unread data after limited reading, the caller must
 /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
-/// (One method to detect remaining data in a message is [`Message::has_buffer_available`])
+/// (If the reader yielded exactly the limited amount of bytes, the caller can test if the reader
+/// will yield one more byte, and if so, fail)
 ///
 /// Note that signatures over a message *can not be verified* with [`Message::verify`]
 /// if the message has not been fully read!
@@ -1029,7 +1030,8 @@ impl<'a> Message<'a> {
     ///
     /// Caution: If the message still contains unread data after limited reading, the caller must
     /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
-    /// (One method to detect remaining data in a message is [`Message::has_buffer_available`])
+    /// (If the reader yielded exactly the limited amount of bytes, the caller can test if the
+    /// reader will yield one more byte, and if so, fail)
     ///
     /// Note that signatures over a message *can not be verified* with [`Message::verify`]
     /// if the message has not been fully read!
@@ -1052,7 +1054,8 @@ impl<'a> Message<'a> {
     ///
     /// Caution: If the message still contains unread data after limited reading, the caller must
     /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
-    /// (One method to detect remaining data in a message is [`Message::has_buffer_available`])
+    /// (If the reader yielded exactly the limited amount of bytes, the caller can test if the
+    /// reader will yield one more byte, and if so, fail)
     ///
     /// Note that signatures over a message *can not be verified* with [`Message::verify`]
     /// if the message has not been fully read!

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -168,8 +168,8 @@ impl BufRead for MessageReader<'_> {
 ///
 /// This type allows consuming an existing message, and processing its various layers:
 ///
-/// If the message contains an encryption layer, then Message attempts to decrypt it,
-/// using material provided with the `decrypt*` function calls.
+/// If the message contains an encryption layer, then `Message` attempts to decrypt it,
+/// using key material provided with the `decrypt*` function calls.
 ///
 /// If the message contains signatures, then these may be verified *after* the message body has
 /// been fully consumed by the caller, using the `verify` function.
@@ -182,19 +182,19 @@ impl BufRead for MessageReader<'_> {
 /// Applications that consume messages need to deal with this fact, in accordance with their
 /// requirements.
 ///
-/// In particular, consumers who need to defend against resource exhaustion must be cautious to
-/// avoid allocating more memory than is available in their context!
+/// In particular, consumers who need to defend against resource exhaustion must avoid allocating
+/// more memory than is available in their context!
 ///
 /// Defensive users should consume `Message` as a streaming reader, wherever possible.
 /// Depending on the use case, wrapping `Message` with a limiting reader
 /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
 /// is a good strategy.)
 ///
-/// Caution: If the message still contains unread data after limited reading (as tested e.g. via
-/// [`Message::has_buffer_available`]), the caller must consider the operation unsuccessful, and
-/// proceed accordingly - e.g. by throwing an error.
+/// Caution: If the message still contains unread data after limited reading, the caller must
+/// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
+/// (One method to detect remaining data in a message is [`Message::has_buffer_available`])
 ///
-/// Also note that signatures over a message *can not be verified* with [`Message::verify`]
+/// Note that signatures over a message *can not be verified* with [`Message::verify`]
 /// if the message has not been fully read!
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]

--- a/src/composed/message/types.rs
+++ b/src/composed/message/types.rs
@@ -1024,10 +1024,17 @@ impl<'a> Message<'a> {
     /// This convenience function is not appropriate for use in environments where "out of memory"
     /// crashes are unacceptable!
     ///
-    /// Callers should consider using a limited reader (e.g. via `Read::take`) to safely consume
-    /// message payloads via the `Read` implementation of this type.
+    /// Defensive users should consume `Message` as a streaming reader, wherever possible.
+    /// Depending on the use case, wrapping `Message` with a limiting reader
+    /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
+    /// is a good strategy.)
     ///
-    /// See the top level [`Message`] documentation for more information!
+    /// Caution: If the message still contains unread data after limited reading, the caller must
+    /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
+    /// (One method to detect remaining data in a message is [`Message::has_buffer_available`])
+    ///
+    /// Note that signatures over a message *can not be verified* with [`Message::verify`]
+    /// if the message has not been fully read!
     pub fn as_data_vec(&mut self) -> io::Result<Vec<u8>> {
         let mut out = Vec::new();
         self.read_to_end(&mut out)?;
@@ -1041,10 +1048,17 @@ impl<'a> Message<'a> {
     /// This convenience function is not appropriate for use in environments where "out of memory"
     /// crashes are unacceptable!
     ///
-    /// Callers should consider using a limited reader (e.g. via `Read::take`) to safely consume
-    /// message payloads via the `Read` implementation of this type.
+    /// Defensive users should consume `Message` as a streaming reader, wherever possible.
+    /// Depending on the use case, wrapping `Message` with a limiting reader
+    /// (e.g. via [`Read::take`](https://doc.rust-lang.org/std/io/trait.Read.html#method.take)
+    /// is a good strategy.)
     ///
-    /// See the top level [`Message`] documentation for more information!
+    /// Caution: If the message still contains unread data after limited reading, the caller must
+    /// consider the operation unsuccessful, and proceed accordingly - e.g. by throwing an error.
+    /// (One method to detect remaining data in a message is [`Message::has_buffer_available`])
+    ///
+    /// Note that signatures over a message *can not be verified* with [`Message::verify`]
+    /// if the message has not been fully read!
     pub fn as_data_string(&mut self) -> io::Result<String> {
         let mut out = String::new();
         self.read_to_string(&mut out)?;


### PR DESCRIPTION
Includes guidance to avoid implicit large allocations.

Thanks to @lintowe for pointing out that the previous documentation for `Message::as_data_vec` and `Message::as_data_string` did not make it sufficiently clear that they involve a risk of resource exhaustion.