### PR TITLE
chore: drop the asm feature for sha1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,6 @@ jobs:
     - name: doc tests
       run: cargo test --doc
 
-    - name: asm
-      if: ${{ matrix.rust == env.RUST_NIGHTLY }}
-      run: cargo nextest run --lib --bins --tests --all --features asm
-
     - name: malformed-artifact-compat
       if: ${{ matrix.rust == env.RUST_NIGHTLY }}
       run: cargo nextest run --lib --bins --tests --all --features malformed-artifact-compat
@@ -73,9 +69,6 @@ jobs:
 
     - name: tests ignored
       run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release
-
-    - name: asm ignored
-      run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release --features asm
 
     - name: pqc ignored
       run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release --features draft-pqc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
     - name: doc tests
       run: cargo test --doc
 
+    - name: asm
+      if: ${{ matrix.rust == env.RUST_NIGHTLY }}
+      run: cargo nextest run --lib --bins --tests --all --features asm
+
     - name: malformed-artifact-compat
       if: ${{ matrix.rust == env.RUST_NIGHTLY }}
       run: cargo nextest run --lib --bins --tests --all --features malformed-artifact-compat
@@ -69,6 +73,9 @@ jobs:
 
     - name: tests ignored
       run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release
+
+    - name: asm ignored
+      run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release --features asm
 
     - name: pqc ignored
       run: cargo nextest run --lib --bins --tests --all --run-ignored ignored-only --release --features draft-pqc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfb-mode"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1146,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+ "md5-asm",
+]
+
+[[package]]
+name = "md5-asm"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19b8ee7fc7d812058d3b708c7f719efd0713d53854648e4223c6fcae709e2df"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1901,6 +1927,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1912,6 +1948,12 @@ dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,15 +264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfb-mode"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,16 +1130,6 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
- "md5-asm",
-]
-
-[[package]]
-name = "md5-asm"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19b8ee7fc7d812058d3b708c7f719efd0713d53854648e4223c6fcae709e2df"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1433,7 +1414,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha1-asm",
  "sha1-checked",
  "sha2",
  "sha3",
@@ -1899,16 +1879,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "sha1-asm",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1931,16 +1901,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "sha2-asm",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1952,12 +1912,6 @@ dependencies = [
  "digest",
  "keccak",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ rand = "0.8.6"
 ripemd = { version = "0.1.3", features = ["oid"] }
 rsa = { version = "0.9.10" }
 sha1 = { version = "0.10.6", features = ["oid"] }
-sha1-asm = { version = "0.5.3", optional = true }
 sha1-checked = { version = "0.10", features = ["zeroize"] }
 sha2 = { version = "0.10.6", features = ["oid"] }
 sha3 = { version = "0.10.8", features = ["oid"] }
@@ -139,7 +138,6 @@ default = ["bzip2"]
 
 # See README.md for features documentation
 bzip2 = ["dep:bzip2"]
-asm = ["dep:sha1-asm", "sha1/asm", "sha2/asm", "md-5/asm"]
 wasm = ["getrandom", "getrandom/js", "web-time"]
 
 large-rsa = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ default = ["bzip2"]
 
 # See README.md for features documentation
 bzip2 = ["dep:bzip2"]
+asm = ["sha2/asm", "md-5/asm"]
 wasm = ["getrandom", "getrandom/js", "web-time"]
 
 large-rsa = []


### PR DESCRIPTION
Rustcrypto `asm` should be opted into by downstream users.

See https://github.com/rpgp/rpgp/pull/812 for context